### PR TITLE
Make git command errors visible

### DIFF
--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -88,3 +88,19 @@ func TestBlameSHAコマンド引数(t *testing.T) {
 		}
 	})
 }
+
+func TestCommitMetaエラー時はプレースホルダーとエラーを返す(t *testing.T) {
+	ctx := context.Background()
+	repo := t.TempDir()
+
+	author, email, date, subject, err := commitMeta(ctx, repo, "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef")
+	if err == nil {
+		t.Fatalf("エラーが返される想定でした")
+	}
+	if author != "-" || email != "-" || date != "-" || subject != "-" {
+		t.Fatalf("エラー時のプレースホルダーが想定外です: %q %q %q %q", author, email, date, subject)
+	}
+	if !strings.Contains(err.Error(), "git show") {
+		t.Fatalf("エラーメッセージにコマンド名が含まれていません: %v", err)
+	}
+}

--- a/internal/engine/types.go
+++ b/internal/engine/types.go
@@ -13,6 +13,14 @@ type Item struct {
 	Message string `json:"message,omitempty"` // commit subject (1行目)
 }
 
+// ItemError は 1 行の取得に失敗した際の情報を表す
+type ItemError struct {
+	File    string `json:"file"`
+	Line    int    `json:"line"`
+	Stage   string `json:"stage"`
+	Message string `json:"message"`
+}
+
 // Options は実行オプション
 type Options struct {
 	Type         string // todo|fixme|both
@@ -31,9 +39,11 @@ type Options struct {
 
 // Result は出力
 type Result struct {
-	Items      []Item `json:"items"`
-	HasComment bool   `json:"has_comment"`
-	HasMessage bool   `json:"has_message"`
-	Total      int    `json:"total"`
-	ElapsedMS  int64  `json:"elapsed_ms"`
+	Items      []Item      `json:"items"`
+	HasComment bool        `json:"has_comment"`
+	HasMessage bool        `json:"has_message"`
+	Total      int         `json:"total"`
+	ElapsedMS  int64       `json:"elapsed_ms"`
+	Errors     []ItemError `json:"errors,omitempty"`
+	ErrorCount int         `json:"error_count"`
 }


### PR DESCRIPTION
## Summary
- keep track of git command failures during scans and expose them in the CLI/web outputs
- add CLI error reporting with non-zero exit code and UI messaging plus supporting tests

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d55e6b65d8832090b5ea8254c51ec4