### PR TITLE
Add documentation comments for pkgsite visibility

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -28,6 +28,10 @@ type match struct {
 	text string
 }
 
+// Run は指定されたオプションに従ってリポジトリを走査し、TODO/FIXME の一覧とメタデータを返します。
+//
+// 成功時には発見した項目と補助情報を保持した Result を返し、
+// 途中で発生したエラー情報は Result.Errors に集約されます。
 func Run(opts Options) (*Result, error) {
 	start := time.Now()
 	if opts.Jobs <= 0 {

--- a/internal/util/progress.go
+++ b/internal/util/progress.go
@@ -12,6 +12,9 @@ func isTTY(f *os.File) bool {
 	return (fi.Mode() & os.ModeCharDevice) != 0
 }
 
+// ShouldShowProgress は進捗表示を有効化すべきかを判定します。
+// force が true の場合は常に true を返し、no が true の場合は常に false を返します。
+// どちらでもない場合は標準出力・標準エラーが TTY かどうかを基準に判定します。
 func ShouldShowProgress(force, no bool) bool {
 	if no {
 		return false
@@ -22,6 +25,7 @@ func ShouldShowProgress(force, no bool) bool {
 	return isTTY(os.Stdout) && isTTY(os.Stderr)
 }
 
+// Progress は処理件数と経過時間から進捗を計算し、標準エラーに表示するための構造体です。
 type Progress struct {
 	total   int
 	start   time.Time
@@ -29,16 +33,21 @@ type Progress struct {
 	done    atomic.Int64
 }
 
+// NewProgress は総件数と有効状態を受け取り、新しい Progress を生成します。
 func NewProgress(total int, enabled bool) *Progress {
 	return &Progress{total: total, start: time.Now(), enabled: enabled}
 }
 
+// Advance は処理済み件数を 1 件進め、最新の件数を返します。
+// 進捗表示が有効な場合は表示を更新します。
 func (p *Progress) Advance() int {
 	done := int(p.done.Add(1))
 	p.Update(done)
 	return done
 }
 
+// Update は処理済み件数を明示的に指定して進捗表示を更新します。
+// マイナスや総件数超過の値が渡された場合でも適切な範囲に丸めます。
 func (p *Progress) Update(done int) {
 	if !p.enabled {
 		return
@@ -67,6 +76,7 @@ func (p *Progress) Update(done int) {
 		done, p.total, percent(done, p.total), eta)
 }
 
+// Done は進捗表示を終了し、描画に使用した行を消去します。
 func (p *Progress) Done() {
 	if !p.enabled {
 		return


### PR DESCRIPTION
## Summary
- add Go doc comments for engine.Run to describe the scan result contract
- document progress utilities so pkgsite shows explanations for exported helpers

## Testing
- make fmt
- make lint
- go test ./...
- make build

------
https://chatgpt.com/codex/tasks/task_e_68d6c23144e483208d86f1ffefaaf6bf