### PR TITLE
git grep の長行を安全に処理する

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -248,6 +248,8 @@ func gitGrep(repo, pattern string) ([]match, error) {
 	}
 	var res []match
 	sc := bufio.NewScanner(bytes.NewReader(out))
+	buf := make([]byte, 0, 1024*1024)
+	sc.Buffer(buf, 1024*1024)
 	for sc.Scan() {
 		line := sc.Text()
 		loc := reLine.FindStringIndex(line)
@@ -261,6 +263,9 @@ func gitGrep(repo, pattern string) ([]match, error) {
 		// normalize path to repo-relative
 		file = filepath.ToSlash(file)
 		res = append(res, match{file: file, line: n, text: text})
+	}
+	if err := sc.Err(); err != nil {
+		return nil, fmt.Errorf("git grep scan: %w", err)
 	}
 	return res, nil
 }

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -1,9 +1,11 @@
 package engine
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -189,5 +191,60 @@ func TestNewItemErrorメッセージ整形(t *testing.T) {
 	fallback := newItemError("file.go", 20, "stage", emptyErr)
 	if fallback.Message != "unknown error" {
 		t.Fatalf("空メッセージの場合は既定文言を利用すべきです: got=%q", fallback.Message)
+	}
+}
+
+func TestGitGrepHandlesLongLines(t *testing.T) {
+	repoDir := t.TempDir()
+
+	runGit(t, repoDir, "init", "-b", "main")
+	runGit(t, repoDir, "config", "user.name", "tester")
+	runGit(t, repoDir, "config", "user.email", "tester@example.com")
+
+	longTail := strings.Repeat("A", 210_000)
+	content := "// TODO " + longTail + "\n"
+	if err := os.WriteFile(filepath.Join(repoDir, "long.go"), []byte(content), 0o644); err != nil {
+		t.Fatalf("failed to write file: %v", err)
+	}
+
+	runGit(t, repoDir, "add", "long.go")
+	runGit(t, repoDir, "commit", "-m", "add long line")
+
+	matches, err := gitGrep(repoDir, "TODO")
+	if err != nil {
+		t.Fatalf("gitGrep returned error: %v", err)
+	}
+
+	if len(matches) != 1 {
+		t.Fatalf("expected 1 match, got %d", len(matches))
+	}
+
+	got := matches[0]
+	if got.file != "long.go" {
+		t.Fatalf("unexpected file: %s", got.file)
+	}
+
+	if got.line != 1 {
+		t.Fatalf("unexpected line: %d", got.line)
+	}
+
+	if !strings.HasPrefix(got.text, "// TODO ") {
+		t.Fatalf("match text missing prefix: %q", got.text[:8])
+	}
+
+	if len(got.text) != len(strings.TrimSuffix(content, "\n")) {
+		t.Fatalf("unexpected text length: got %d want %d", len(got.text), len(content)-1)
+	}
+}
+
+func runGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("git %s failed: %v\n%s", strings.Join(args, " "), err, stderr.String())
 	}
 }

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -201,7 +201,8 @@ func TestGitGrepHandlesLongLines(t *testing.T) {
 	runGit(t, repoDir, "config", "user.name", "tester")
 	runGit(t, repoDir, "config", "user.email", "tester@example.com")
 
-	longTail := strings.Repeat("A", 210_000)
+	const testLongLineSize = 210_000
+	longTail := strings.Repeat("A", testLongLineSize)
 	content := "// TODO " + longTail + "\n"
 	if err := os.WriteFile(filepath.Join(repoDir, "long.go"), []byte(content), 0o644); err != nil {
 		t.Fatalf("failed to write file: %v", err)

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -228,8 +228,16 @@ func TestGitGrepHandlesLongLines(t *testing.T) {
 		t.Fatalf("unexpected line: %d", got.line)
 	}
 
-	if !strings.HasPrefix(got.text, "// TODO ") {
-		t.Fatalf("match text missing prefix: %q", got.text[:8])
+	const todoPrefix = "// TODO "
+	if !strings.HasPrefix(got.text, todoPrefix) {
+		prefixLen := len(todoPrefix)
+		var gotPrefix string
+		if len(got.text) >= prefixLen {
+			gotPrefix = got.text[:prefixLen]
+		} else {
+			gotPrefix = got.text
+		}
+		t.Fatalf("match text missing prefix: %q", gotPrefix)
 	}
 
 	if len(got.text) != len(strings.TrimSuffix(content, "\n")) {


### PR DESCRIPTION
## Summary
- git grep のスキャナバッファを 1MB に拡張し、走査エラーを呼び出し側へ返すようにしました
- 200KB 超の TODO 行でも欠落しないことを確認する回帰テストを追加しました

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d7d50f746083209f52c85a4d241811