### PR TITLE
Simplify git blame argument construction

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -270,12 +270,17 @@ func gitGrep(repo, pattern string) ([]match, error) {
 	return res, nil
 }
 
-func blameSHA(ctx context.Context, repo, file string, line int, ignoreWS bool) (string, error) {
+func buildBlameArgs(file string, line int, ignoreWS bool) []string {
 	args := []string{"blame"}
 	if ignoreWS {
 		args = append(args, "-w")
 	}
-	args = append(args, "--line-porcelain", "-L", fmt.Sprintf("%d,%d", line, line), "--", file)
+	lineSpec := fmt.Sprintf("%d,%d", line, line)
+	return append(args, "--line-porcelain", "-L", lineSpec, "--", file)
+}
+
+func blameSHA(ctx context.Context, repo, file string, line int, ignoreWS bool) (string, error) {
+	args := buildBlameArgs(file, line, ignoreWS)
 	cmd := exec.CommandContext(ctx, "git", args...)
 	cmd.Dir = repo
 	out, err := cmd.Output()


### PR DESCRIPTION
## Summary
- centralize git blame argument construction so -w is appended before porcelain options
- reuse the helper in blameSHA to keep whitespace handling simple

Fixes #9

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d7dcc6d5d8832088d9c6b26cd7ffef