### PR TITLE
docs: sync CLI option docs across languages

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -89,16 +89,42 @@ make build
 
 ## CLI オプション（抜粋）
 
-- `--type {todo|fixme|both}` : 対象タグ（既定: both）
-- `--mode {last|first}` : 作者の定義（既定: last）
-- `--author REGEX` : 作者名/メールの正規表現フィルタ
-- `--with-comment` / `--with-message` / `--full`
-- `--truncate N` / `--truncate-comment N` / `--truncate-message N`
-- `--output {table|tsv|json}`
-- `--no-progress` / `--progress`
-- `--no-ignore-ws` : `git blame` に `-w` を付けない（空白変更も最新扱い）
+### 検索・作者判定
 
-ヘルプ：`./bin/todox -h`（英語/日本語切り替え対応）
+- `-t, --type {todo|fixme|both}` : スキャン対象（既定: both）
+- `-m, --mode {last|first}` : 作者の定義（既定: last）
+- `-a, --author REGEX` : 作者名/メールの正規表現フィルタ（拡張正規表現）
+
+### 出力形式
+
+- `-o, --output {table|tsv|json}` : 出力フォーマット（既定: table）
+
+### 追加列（非表示が既定）
+
+- `--with-comment` : TODO/FIXME 行を表示
+- `--with-snippet` : `--with-comment` のエイリアス（後方互換用途）
+- `--with-message` : コミットサマリ（1 行目）を表示
+- `--full` : `--with-comment --with-message` のショートカット
+
+### 文字数制御
+
+- `--truncate N` : COMMENT/MESSAGE を両方 N 文字に丸める（0 で無制限）
+- `--truncate-comment N` : COMMENT だけ丸める
+- `--truncate-message N` : MESSAGE だけ丸める
+
+### 進捗・ blame の振る舞い
+
+- `--no-progress` / `--progress` : 進捗表示を抑止／強制
+- `--no-ignore-ws` : `git blame` で `-w` を使わない（空白変更も最新扱い）
+
+### ヘルプ・言語設定
+
+- `-h, --help [en|ja]` : ヘルプを表示（既定は英語。`ja` で日本語）
+- `--help=ja`, `--help-ja` : ワンショットで日本語ヘルプを表示
+- `--lang {en|ja}` : 現在の実行に使うヘルプ言語を指定
+- `GTA_LANG=ja`（環境変数）: 既定ヘルプ言語を日本語に変更（`GIT_TODO_AUTHORS_LANG` も使用可）
+
+ヘルプ：`./bin/todox -h`（英語/日本語の両対応、例付き）
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -88,16 +88,42 @@ make build
 
 ## CLI options (highlights)
 
-- `--type {todo|fixme|both}`: which markers to scan (default: both)
-- `--mode {last|first}`: author definition (default: last)
-- `--author REGEX`: filter by author name or email
-- `--with-comment` / `--with-message` / `--full`
-- `--truncate N` / `--truncate-comment N` / `--truncate-message N`
-- `--output {table|tsv|json}`
-- `--no-progress` / `--progress`
+### Search & attribution
+
+- `-t, --type {todo|fixme|both}`: which markers to scan (default: both)
+- `-m, --mode {last|first}`: author definition (default: last)
+- `-a, --author REGEX`: filter by author name or email (extended regex)
+
+### Output selection
+
+- `-o, --output {table|tsv|json}`: choose the output format (default: table)
+
+### Extra columns (hidden by default)
+
+- `--with-comment`: include the TODO/FIXME line text
+- `--with-snippet`: alias of `--with-comment` (kept for backward compatibility)
+- `--with-message`: include the commit subject (first line)
+- `--full`: shorthand for `--with-comment --with-message`
+
+### Truncation controls
+
+- `--truncate N`: truncate both COMMENT and MESSAGE to `N` characters (0 = unlimited)
+- `--truncate-comment N`: truncate only COMMENT
+- `--truncate-message N`: truncate only MESSAGE
+
+### Progress / blame behaviour
+
+- `--no-progress` / `--progress`: disable or force the progress display
 - `--no-ignore-ws`: run `git blame` without `-w` so whitespace-only edits are considered latest
 
-Full help: `./bin/todox -h` (bilingual output).
+### Help & language
+
+- `-h, --help [en|ja]`: show help (English by default, pass `ja` for Japanese)
+- `--help=ja`, `--help-ja`: convenient aliases to show Japanese help immediately
+- `--lang {en|ja}`: set the help language for the current invocation
+- `GTA_LANG=ja` (environment): default to Japanese help (`GIT_TODO_AUTHORS_LANG` also works)
+
+Full help: `./bin/todox -h` (bilingual output and examples).
 
 ---
 


### PR DESCRIPTION
## Summary
- reorganize the CLI options section in README to match the latest help output and include aliases
- mirror the same structure and content in README-ja so the English/Japanese docs stay aligned

## Testing
- make build

Closes #14.

------
https://chatgpt.com/codex/tasks/task_e_68d7fb7a36b48320971136b61a3bab21