### PR TITLE
Add age column output and sorting options

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -14,6 +14,7 @@
 - `--mode first`：その `TODO/FIXME` を**最初に導入**した人（`git log -L`）
 - フィルタ：`--author`, `--type {todo|fixme|both}`
 - 追加列：`--with-comment`（行本文を TODO/FIXME から表示）、`--with-message`（コミット件名 1 行目）、`--full`
+- 経過日数：`--with-age` で `AGE` 列（日数）を追加し、`--sort -age` で古い順に並び替え。JSON は常に `age_days` を含む
 - 文字数制御：`--truncate`, `--truncate-comment`, `--truncate-message`
 - 出力：`table` / `tsv` / `json`
 - 進捗表示：TTY のみ stderr に 1 行上書き（`--no-progress` あり）
@@ -61,6 +62,9 @@ make build
 # TSV / JSON で出力
 ./bin/todox --output tsv  > todo.tsv
 ./bin/todox --output json > todo.json
+
+# AGE 列を出して古い順に並び替え
+./bin/todox --with-age --sort -age
 ```
 
 ### Web モード
@@ -98,13 +102,19 @@ make build
 ### 出力形式
 
 - `-o, --output {table|tsv|json}` : 出力フォーマット（既定: table）
+- JSON 出力には `age_days` フィールドが常に含まれます（`--with-age` 不要）
 
 ### 追加列（非表示が既定）
 
 - `--with-comment` : TODO/FIXME 行を表示
 - `--with-snippet` : `--with-comment` のエイリアス（後方互換用途）
 - `--with-message` : コミットサマリ（1 行目）を表示
+- `--with-age` : `AGE` 列（日数）を table / TSV に追加
 - `--full` : `--with-comment --with-message` のショートカット
+
+### ソート
+
+- `--sort -age` : 経過日数の降順（古い順）に並び替え
 
 ### 文字数制御
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ identify **who introduced or last touched** those lines in seconds—either from
 - `--mode first`: show the **original author** who introduced the TODO/FIXME (`git log -L`).
 - Filtering options: `--author`, `--type {todo|fixme|both}`.
 - Extra columns: `--with-comment`, `--with-message`, `--full` (shortcut for both with truncation).
+- Age insights: `--with-age` adds an `AGE` column (days since author date) and `--sort -age` prioritises older items. JSON output always includes `age_days`.
 - Length control: `--truncate`, `--truncate-comment`, `--truncate-message`.
 - Output formats: `table`, `tsv`, `json`.
 - Progress bar: one-line TTY updates (disable with `--no-progress`).
@@ -60,6 +61,9 @@ make build
 # Export as TSV or JSON
 ./bin/todox --output tsv  > todo.tsv
 ./bin/todox --output json > todo.json
+
+# Add AGE column and prioritise the oldest entries
+./bin/todox --with-age --sort -age
 ```
 
 ### Web mode
@@ -97,13 +101,19 @@ make build
 ### Output selection
 
 - `-o, --output {table|tsv|json}`: choose the output format (default: table)
+- JSON output always contains an `age_days` field regardless of `--with-age`
 
 ### Extra columns (hidden by default)
 
 - `--with-comment`: include the TODO/FIXME line text
 - `--with-snippet`: alias of `--with-comment` (kept for backward compatibility)
 - `--with-message`: include the commit subject (first line)
+- `--with-age`: add an `AGE` column (days since the author date) for table/TSV output
 - `--full`: shorthand for `--with-comment --with-message`
+
+### Sorting
+
+- `--sort -age`: sort by age in descending order (oldest entries first)
 
 ### Truncation controls
 

--- a/cmd/todox/flags_test.go
+++ b/cmd/todox/flags_test.go
@@ -95,6 +95,25 @@ func TestHelpOutputJapanese(t *testing.T) {
 	}
 }
 
+func TestParseScanArgsWithAgeとSort(t *testing.T) {
+	cfg, err := parseScanArgs([]string{"--with-age", "--sort", "-age"}, "en")
+	if err != nil {
+		t.Fatalf("parseScanArgs failed: %v", err)
+	}
+	if !cfg.opts.WithAge {
+		t.Fatalf("WithAge should be enabled")
+	}
+	if cfg.sortKey != "-age" {
+		t.Fatalf("sortKey should be -age: got %q", cfg.sortKey)
+	}
+}
+
+func TestParseScanArgsUnsupportedSortはエラー(t *testing.T) {
+	if _, err := parseScanArgs([]string{"--sort", "age"}, "en"); err == nil {
+		t.Fatal("unsupported sort key should produce error")
+	}
+}
+
 func runTodox(t *testing.T, args ...string) string {
 	t.Helper()
 	cmd := exec.Command("go", append([]string{"run", "."}, args...)...)

--- a/internal/engine/types.go
+++ b/internal/engine/types.go
@@ -1,11 +1,14 @@
 package engine
 
+import "time"
+
 // Item は 1 件の TODO/FIXME を表す
 type Item struct {
 	Kind    string `json:"kind"` // TODO | FIXME | TODO|FIXME
 	Author  string `json:"author"`
 	Email   string `json:"email"`
-	Date    string `json:"date"`   // author date (iso-strict-local)
+	Date    string `json:"date"` // author date (iso-strict-local)
+	AgeDays int    `json:"age_days"`
 	Commit  string `json:"commit"` // full SHA
 	File    string `json:"file"`
 	Line    int    `json:"line"`
@@ -28,6 +31,7 @@ type Options struct {
 	AuthorRegex  string
 	WithComment  bool
 	WithMessage  bool
+	WithAge      bool
 	TruncAll     int
 	TruncComment int
 	TruncMessage int
@@ -35,6 +39,7 @@ type Options struct {
 	Jobs         int
 	RepoDir      string
 	Progress     bool
+	Now          time.Time
 }
 
 // Result は出力


### PR DESCRIPTION
## Summary
- add age day tracking to engine items and expose the value in JSON and CLI outputs
- introduce `--with-age` and `--sort -age` flags with table/TSV formatting updates and stable sorting
- update documentation and tests for the new age column and sorting behaviour

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d802297798832098663f56f8382617