### PR TITLE
Add age column output and sorting

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -13,7 +13,8 @@
 - `--mode last`（既定）：その行を**最後に変更**した人（`git blame`）
 - `--mode first`：その `TODO/FIXME` を**最初に導入**した人（`git log -L`）
 - フィルタ：`--author`, `--type {todo|fixme|both}`
-- 追加列：`--with-comment`（行本文を TODO/FIXME から表示）、`--with-message`（コミット件名 1 行目）、`--full`
+- 追加列：`--with-comment`（行本文を TODO/FIXME から表示）、`--with-message`（コミット件名 1 行目）、`--with-age`（日数）、`--full`
+- 並び替え：第一歩として `--sort -age`（古い順）
 - 文字数制御：`--truncate`, `--truncate-comment`, `--truncate-message`
 - 出力：`table` / `tsv` / `json`
 - 進捗表示：TTY のみ stderr に 1 行上書き（`--no-progress` あり）
@@ -57,6 +58,9 @@ make build
 
 # 作者名/メールで絞り込み（正規表現）
 ./bin/todox -a 'Alice|alice@example.com'
+
+# 古い TODO/FIXME を優先表示
+./bin/todox --with-age --sort -age
 
 # TSV / JSON で出力
 ./bin/todox --output tsv  > todo.tsv
@@ -104,6 +108,7 @@ make build
 - `--with-comment` : TODO/FIXME 行を表示
 - `--with-snippet` : `--with-comment` のエイリアス（後方互換用途）
 - `--with-message` : コミットサマリ（1 行目）を表示
+- `--with-age` : AGE 列（日数）を表示
 - `--full` : `--with-comment --with-message` のショートカット
 
 ### 文字数制御
@@ -111,6 +116,10 @@ make build
 - `--truncate N` : COMMENT/MESSAGE を両方 N 文字に丸める（0 で無制限）
 - `--truncate-comment N` : COMMENT だけ丸める
 - `--truncate-message N` : MESSAGE だけ丸める
+
+### 並び替え
+
+- `--sort -age` : 古い TODO/FIXME を先頭に表示（同値は `file:line`）
 
 ### 進捗・ blame の振る舞い
 
@@ -170,7 +179,7 @@ Homebrew tap を自動更新したい場合は、事前に以下を準備して�
 
 ## ロードマップ（抜粋）
 
-- `--with-age`（AGE 列）と `--sort`, `--group-by`
+- ✅ 第一段階: `--with-age` と `--sort -age`（今後は grouping を予定）
 - リモート（GitHub/GitLab/Gitea）への行リンク生成
 - Markdown / CSV 出力、fzf/TUI、`-M/-C` での行移動検出
 - ファイル単位 blame の一括取得による高速化

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ identify **who introduced or last touched** those lines in seconds—either from
 - `--mode last` (default): show the **most recent author** of the line (`git blame`).
 - `--mode first`: show the **original author** who introduced the TODO/FIXME (`git log -L`).
 - Filtering options: `--author`, `--type {todo|fixme|both}`.
-- Extra columns: `--with-comment`, `--with-message`, `--full` (shortcut for both with truncation).
+- Extra columns: `--with-comment`, `--with-message`, `--with-age`, `--full` (shortcut for both with truncation).
+- Sorting: first step delivered with `--sort -age` (oldest TODO/FIXME first).
 - Length control: `--truncate`, `--truncate-comment`, `--truncate-message`.
 - Output formats: `table`, `tsv`, `json`.
 - Progress bar: one-line TTY updates (disable with `--no-progress`).
@@ -56,6 +57,9 @@ make build
 
 # Filter by author name or email (regular expression)
 ./bin/todox -a 'Alice|alice@example.com'
+
+# Highlight the oldest TODO/FIXME entries
+./bin/todox --with-age --sort -age
 
 # Export as TSV or JSON
 ./bin/todox --output tsv  > todo.tsv
@@ -103,6 +107,7 @@ make build
 - `--with-comment`: include the TODO/FIXME line text
 - `--with-snippet`: alias of `--with-comment` (kept for backward compatibility)
 - `--with-message`: include the commit subject (first line)
+- `--with-age`: show the AGE column (days since the recorded author date)
 - `--full`: shorthand for `--with-comment --with-message`
 
 ### Truncation controls
@@ -110,6 +115,10 @@ make build
 - `--truncate N`: truncate both COMMENT and MESSAGE to `N` characters (0 = unlimited)
 - `--truncate-comment N`: truncate only COMMENT
 - `--truncate-message N`: truncate only MESSAGE
+
+### Sorting
+
+- `--sort -age`: list oldest TODO/FIXME items first (ties fall back to `file:line`)
 
 ### Progress / blame behaviour
 
@@ -168,7 +177,7 @@ To update a Homebrew tap automatically, prepare:
 
 ## Roadmap (highlights)
 
-- `--with-age` column plus sorting / grouping options
+- ✅ First milestone: `--with-age` column with `--sort -age` (grouping options still planned)
 - Deep links to remote hosts (GitHub / GitLab / Gitea)
 - Additional outputs (Markdown, CSV), fzf/TUI integration, detection of moved lines via `-M/-C`
 - Faster scans by batching file-level blame queries

--- a/cmd/todox/flags_test.go
+++ b/cmd/todox/flags_test.go
@@ -81,6 +81,19 @@ func TestParseScanArgsFullSetsDefaultTrunc(t *testing.T) {
 	}
 }
 
+func TestParseScanArgsWithAgeAndSort(t *testing.T) {
+	cfg, err := parseScanArgs([]string{"--with-age", "--sort", "-age"}, "en")
+	if err != nil {
+		t.Fatalf("parseScanArgs failed: %v", err)
+	}
+	if !cfg.opts.WithAge {
+		t.Fatalf("WithAge flag should be true")
+	}
+	if cfg.sortKey != "-age" {
+		t.Fatalf("sortKey mismatch: got %q", cfg.sortKey)
+	}
+}
+
 func TestHelpOutputEnglish(t *testing.T) {
 	output := runTodox(t, "-h")
 	if !strings.Contains(output, "todox — Find who wrote TODO/FIXME") {

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -10,6 +10,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestBlameSHAコマンド引数(t *testing.T) {
@@ -191,6 +192,28 @@ func TestNewItemErrorメッセージ整形(t *testing.T) {
 	fallback := newItemError("file.go", 20, "stage", emptyErr)
 	if fallback.Message != "unknown error" {
 		t.Fatalf("空メッセージの場合は既定文言を利用すべきです: got=%q", fallback.Message)
+	}
+}
+
+func TestAgeDays計算(t *testing.T) {
+	now := time.Date(2024, time.July, 20, 12, 0, 0, 0, time.UTC)
+	cases := []struct {
+		name   string
+		author time.Time
+		want   int
+	}{
+		{name: "同日", author: time.Date(2024, time.July, 20, 0, 0, 0, 0, time.UTC), want: 0},
+		{name: "1日未満", author: time.Date(2024, time.July, 20, 11, 0, 0, 0, time.UTC), want: 0},
+		{name: "3日超", author: time.Date(2024, time.July, 17, 11, 59, 59, 0, time.UTC), want: 3},
+		{name: "未来日時", author: time.Date(2024, time.July, 21, 0, 0, 0, 0, time.UTC), want: 0},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ageDays(now, tc.author); got != tc.want {
+				t.Fatalf("ageDaysの計算結果が想定外です: got=%d want=%d", got, tc.want)
+			}
+		})
 	}
 }
 

--- a/internal/engine/types.go
+++ b/internal/engine/types.go
@@ -1,12 +1,15 @@
 package engine
 
+import "time"
+
 // Item は 1 件の TODO/FIXME を表す
 type Item struct {
 	Kind    string `json:"kind"` // TODO | FIXME | TODO|FIXME
 	Author  string `json:"author"`
 	Email   string `json:"email"`
-	Date    string `json:"date"`   // author date (iso-strict-local)
-	Commit  string `json:"commit"` // full SHA
+	Date    string `json:"date"`     // author date (iso-strict-local)
+	AgeDays int    `json:"age_days"` // (now - author date) in days
+	Commit  string `json:"commit"`   // full SHA
 	File    string `json:"file"`
 	Line    int    `json:"line"`
 	Comment string `json:"comment,omitempty"` // TODO/FIXME からの行
@@ -28,6 +31,7 @@ type Options struct {
 	AuthorRegex  string
 	WithComment  bool
 	WithMessage  bool
+	WithAge      bool
 	TruncAll     int
 	TruncComment int
 	TruncMessage int
@@ -35,6 +39,7 @@ type Options struct {
 	Jobs         int
 	RepoDir      string
 	Progress     bool
+	Now          time.Time
 }
 
 // Result は出力


### PR DESCRIPTION
## Summary
- compute `age_days` for engine items and expose configuration for deterministic testing
- add `--with-age` output column and `--sort -age` handling across CLI, API, and formatters
- document the new options and cover them with unit tests

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d802297798832098663f56f8382617