### PR TITLE
Add age column and sorting support

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -13,7 +13,8 @@
 - `--mode last`（既定）：その行を**最後に変更**した人（`git blame`）
 - `--mode first`：その `TODO/FIXME` を**最初に導入**した人（`git log -L`）
 - フィルタ：`--author`, `--type {todo|fixme|both}`
-- 追加列：`--with-comment`（行本文を TODO/FIXME から表示）、`--with-message`（コミット件名 1 行目）、`--full`
+- 追加列：`--with-comment`（行本文を TODO/FIXME から表示）、`--with-message`（コミット件名 1 行目）、`--full`、`--with-age`（table/tsv に経過日数列。JSON は常に `age_days` を含む）
+- 並び替え：`--sort -age` で古い TODO/FIXME から優先表示
 - 文字数制御：`--truncate`, `--truncate-comment`, `--truncate-message`
 - 出力：`table` / `tsv` / `json`
 - 進捗表示：TTY のみ stderr に 1 行上書き（`--no-progress` あり）
@@ -57,6 +58,9 @@ make build
 
 # 作者名/メールで絞り込み（正規表現）
 ./bin/todox -a 'Alice|alice@example.com'
+
+# 経過日数の列を表示し、古い TODO/FIXME から並べる
+./bin/todox --with-age --sort -age
 
 # TSV / JSON で出力
 ./bin/todox --output tsv  > todo.tsv
@@ -105,6 +109,11 @@ make build
 - `--with-snippet` : `--with-comment` のエイリアス（後方互換用途）
 - `--with-message` : コミットサマリ（1 行目）を表示
 - `--full` : `--with-comment --with-message` のショートカット
+- `--with-age` : table / tsv に AGE 列（著者日付からの経過日数）を追加。JSON では `age_days` が常に出力されます
+
+### 並び替え
+
+- `--sort -age` : 経過日数が長い順（古い TODO/FIXME 優先。タイブレークは file:line）
 
 ### 文字数制御
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ identify **who introduced or last touched** those lines in seconds—either from
 - `--mode last` (default): show the **most recent author** of the line (`git blame`).
 - `--mode first`: show the **original author** who introduced the TODO/FIXME (`git log -L`).
 - Filtering options: `--author`, `--type {todo|fixme|both}`.
-- Extra columns: `--with-comment`, `--with-message`, `--full` (shortcut for both with truncation).
+- Extra columns: `--with-comment`, `--with-message`, `--full` (shortcut for both with truncation), plus `--with-age` for table/tsv (JSON always includes `age_days`).
+- Sorting: `--sort -age` to prioritise the oldest findings.
 - Length control: `--truncate`, `--truncate-comment`, `--truncate-message`.
 - Output formats: `table`, `tsv`, `json`.
 - Progress bar: one-line TTY updates (disable with `--no-progress`).
@@ -56,6 +57,9 @@ make build
 
 # Filter by author name or email (regular expression)
 ./bin/todox -a 'Alice|alice@example.com'
+
+# Surface the oldest TODO/FIXME entries with an AGE column
+./bin/todox --with-age --sort -age
 
 # Export as TSV or JSON
 ./bin/todox --output tsv  > todo.tsv
@@ -104,6 +108,11 @@ make build
 - `--with-snippet`: alias of `--with-comment` (kept for backward compatibility)
 - `--with-message`: include the commit subject (first line)
 - `--full`: shorthand for `--with-comment --with-message`
+- `--with-age`: append an AGE column (days since author date) in table/tsv output; JSON responses always include `age_days`
+
+### Sorting
+
+- `--sort -age`: list the oldest TODO/FIXME entries first (falls back to file:line for ties)
 
 ### Truncation controls
 

--- a/cmd/todox/flags_test.go
+++ b/cmd/todox/flags_test.go
@@ -81,6 +81,19 @@ func TestParseScanArgsFullSetsDefaultTrunc(t *testing.T) {
 	}
 }
 
+func TestParseScanArgsWithAgeAndSort(t *testing.T) {
+	cfg, err := parseScanArgs([]string{"--with-age", "--sort", "-age"}, "en")
+	if err != nil {
+		t.Fatalf("parseScanArgs failed: %v", err)
+	}
+	if !cfg.withAge {
+		t.Fatal("withAge should be true when --with-age is specified")
+	}
+	if cfg.sortKey != "-age" {
+		t.Fatalf("sortKey mismatch: got %q", cfg.sortKey)
+	}
+}
+
 func TestHelpOutputEnglish(t *testing.T) {
 	output := runTodox(t, "-h")
 	if !strings.Contains(output, "todox — Find who wrote TODO/FIXME") {

--- a/cmd/todox/sort_test.go
+++ b/cmd/todox/sort_test.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/example/todox/internal/engine"
+)
+
+func TestApplySortAge降順に並ぶ(t *testing.T) {
+	items := []engine.Item{
+		{File: "b.go", Line: 10, AgeDays: 3},
+		{File: "a.go", Line: 5, AgeDays: 3},
+		{File: "c.go", Line: 1, AgeDays: 7},
+		{File: "a.go", Line: 2, AgeDays: 7},
+	}
+
+	if err := applySort(items, "-age"); err != nil {
+		t.Fatalf("applySort returned error: %v", err)
+	}
+
+	want := []engine.Item{
+		{File: "a.go", Line: 2, AgeDays: 7},
+		{File: "c.go", Line: 1, AgeDays: 7},
+		{File: "a.go", Line: 5, AgeDays: 3},
+		{File: "b.go", Line: 10, AgeDays: 3},
+	}
+
+	for i := range want {
+		if items[i].File != want[i].File || items[i].Line != want[i].Line || items[i].AgeDays != want[i].AgeDays {
+			t.Fatalf("unexpected order at %d: got=%v want=%v", i, items[i], want[i])
+		}
+	}
+}
+
+func TestApplySortUnknownKeyはエラー(t *testing.T) {
+	items := make([]engine.Item, 0)
+	if err := applySort(items, "date"); err == nil {
+		t.Fatal("unsupported key should return error")
+	}
+}

--- a/internal/engine/types.go
+++ b/internal/engine/types.go
@@ -1,12 +1,15 @@
 package engine
 
+import "time"
+
 // Item は 1 件の TODO/FIXME を表す
 type Item struct {
 	Kind    string `json:"kind"` // TODO | FIXME | TODO|FIXME
 	Author  string `json:"author"`
 	Email   string `json:"email"`
-	Date    string `json:"date"`   // author date (iso-strict-local)
-	Commit  string `json:"commit"` // full SHA
+	Date    string `json:"date"`     // author date (iso-strict-local)
+	AgeDays int    `json:"age_days"` // author date からの経過日数
+	Commit  string `json:"commit"`   // full SHA
 	File    string `json:"file"`
 	Line    int    `json:"line"`
 	Comment string `json:"comment,omitempty"` // TODO/FIXME からの行
@@ -35,6 +38,7 @@ type Options struct {
 	Jobs         int
 	RepoDir      string
 	Progress     bool
+	Now          time.Time
 }
 
 // Result は出力


### PR DESCRIPTION
## Summary
- compute age_days for each TODO/FIXME item and expose it in the engine results
- add CLI support for --with-age and --sort -age plus formatted table/tsv output and documentation updates
- extend automated tests for sorting and output formatting, including new unit tests for age calculations

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d802297798832098663f56f8382617