### PR TITLE
Implement unified sorting and field selection

### DIFF
--- a/cmd/todox/fields.go
+++ b/cmd/todox/fields.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+)
+
+type FieldSelection struct {
+	Fields     []string
+	Provided   bool
+	HasComment bool
+	HasMessage bool
+	HasAge     bool
+}
+
+var fieldHeaders = map[string]string{
+	"type":     "TYPE",
+	"author":   "AUTHOR",
+	"email":    "EMAIL",
+	"date":     "DATE",
+	"age":      "AGE",
+	"commit":   "COMMIT",
+	"location": "LOCATION",
+	"comment":  "COMMENT",
+	"message":  "MESSAGE",
+}
+
+func ParseFieldSpec(raw string) (FieldSelection, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return FieldSelection{}, nil
+	}
+	parts := strings.Split(raw, ",")
+	fields := make([]string, 0, len(parts))
+	seen := map[string]bool{}
+	sel := FieldSelection{Provided: true}
+	for _, part := range parts {
+		name := strings.ToLower(strings.TrimSpace(part))
+		if name == "" {
+			return FieldSelection{}, fmt.Errorf("invalid field name: empty segment")
+		}
+		canonical, ok := canonicalFieldName(name)
+		if !ok {
+			return FieldSelection{}, fmt.Errorf("unknown field: %s", part)
+		}
+		if seen[canonical] {
+			continue
+		}
+		seen[canonical] = true
+		switch canonical {
+		case "comment":
+			sel.HasComment = true
+		case "message":
+			sel.HasMessage = true
+		case "age":
+			sel.HasAge = true
+		}
+		fields = append(fields, canonical)
+	}
+	sel.Fields = fields
+	return sel, nil
+}
+
+func canonicalFieldName(name string) (string, bool) {
+	switch name {
+	case "age_days":
+		name = "age"
+	}
+	_, ok := fieldHeaders[name]
+	return name, ok
+}
+
+func DetermineFields(sel FieldSelection, hasComment, hasMessage bool, withAge bool) ([]string, bool) {
+	if sel.Provided {
+		return sel.Fields, sel.HasAge
+	}
+	fields := []string{"type", "author", "email", "date"}
+	if withAge {
+		fields = append(fields, "age")
+	}
+	fields = append(fields, "commit", "location")
+	if hasComment {
+		fields = append(fields, "comment")
+	}
+	if hasMessage {
+		fields = append(fields, "message")
+	}
+	return fields, withAge
+}
+
+func containsField(fields []string, name string) bool {
+	for _, f := range fields {
+		if f == name {
+			return true
+		}
+	}
+	return false
+}
+
+func headerForField(name string) string {
+	if h, ok := fieldHeaders[name]; ok {
+		return h
+	}
+	return strings.ToUpper(name)
+}

--- a/cmd/todox/flags_test.go
+++ b/cmd/todox/flags_test.go
@@ -89,14 +89,30 @@ func TestParseScanArgsWithAgeAndSort(t *testing.T) {
 	if !cfg.withAge {
 		t.Fatal("--with-age should enable AGE column")
 	}
-	if cfg.sortKey != "-age" {
-		t.Fatalf("sortKey mismatch: got %q", cfg.sortKey)
+	if len(cfg.sortSpec.Keys) != 1 {
+		t.Fatalf("sortSpec should have 1 key: %+v", cfg.sortSpec)
+	}
+	if cfg.sortSpec.Keys[0] != (SortKey{Name: "age", Desc: true}) {
+		t.Fatalf("sortSpec first key mismatch: %+v", cfg.sortSpec.Keys[0])
 	}
 }
 
 func TestParseScanArgsRejectsUnknownSort(t *testing.T) {
-	if _, err := parseScanArgs([]string{"--sort", "author"}, "en"); err == nil {
+	if _, err := parseScanArgs([]string{"--sort", "unknown"}, "en"); err == nil {
 		t.Fatal("expected error for unsupported --sort value")
+	}
+}
+
+func TestParseScanArgsFields指定はコメント列を有効化する(t *testing.T) {
+	cfg, err := parseScanArgs([]string{"--fields", "type,comment"}, "en")
+	if err != nil {
+		t.Fatalf("parseScanArgs failed: %v", err)
+	}
+	if !cfg.opts.WithComment {
+		t.Fatal("fields指定でコメントが有効化されていません")
+	}
+	if !cfg.fieldSel.Provided || !containsField(cfg.fieldSel.Fields, "comment") {
+		t.Fatalf("fieldSelが期待通りではありません: %+v", cfg.fieldSel)
 	}
 }
 

--- a/cmd/todox/sortspec.go
+++ b/cmd/todox/sortspec.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/example/todox/internal/engine"
+)
+
+type SortKey struct {
+	Name string
+	Desc bool
+}
+
+type SortSpec struct {
+	Keys []SortKey
+}
+
+func ParseSortSpec(raw string) (SortSpec, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return SortSpec{}, nil
+	}
+	parts := strings.Split(raw, ",")
+	keys := make([]SortKey, 0, len(parts))
+	for _, part := range parts {
+		p := strings.TrimSpace(part)
+		if p == "" {
+			return SortSpec{}, fmt.Errorf("invalid sort key: empty segment")
+		}
+		desc := false
+		switch p[0] {
+		case '+':
+			p = p[1:]
+		case '-':
+			desc = true
+			p = p[1:]
+		}
+		name := strings.ToLower(p)
+		switch name {
+		case "age", "age_days":
+			keys = append(keys, SortKey{Name: "age", Desc: desc})
+		case "date":
+			keys = append(keys, SortKey{Name: "age", Desc: !desc})
+		case "author", "email", "type", "file", "line", "commit":
+			keys = append(keys, SortKey{Name: name, Desc: desc})
+		case "location":
+			keys = append(keys, SortKey{Name: "file", Desc: desc})
+			keys = append(keys, SortKey{Name: "line", Desc: desc})
+		default:
+			return SortSpec{}, fmt.Errorf("unknown sort key: %s", part)
+		}
+	}
+	return SortSpec{Keys: keys}, nil
+}
+
+func ApplySort(items []engine.Item, spec SortSpec) {
+	if len(spec.Keys) == 0 {
+		return
+	}
+	sort.SliceStable(items, func(i, j int) bool {
+		for _, key := range spec.Keys {
+			switch key.Name {
+			case "age":
+				if items[i].AgeDays != items[j].AgeDays {
+					if key.Desc {
+						return items[i].AgeDays > items[j].AgeDays
+					}
+					return items[i].AgeDays < items[j].AgeDays
+				}
+			case "author":
+				if items[i].Author != items[j].Author {
+					if key.Desc {
+						return items[i].Author > items[j].Author
+					}
+					return items[i].Author < items[j].Author
+				}
+			case "email":
+				if items[i].Email != items[j].Email {
+					if key.Desc {
+						return items[i].Email > items[j].Email
+					}
+					return items[i].Email < items[j].Email
+				}
+			case "type":
+				if items[i].Kind != items[j].Kind {
+					if key.Desc {
+						return items[i].Kind > items[j].Kind
+					}
+					return items[i].Kind < items[j].Kind
+				}
+			case "file":
+				if items[i].File != items[j].File {
+					if key.Desc {
+						return items[i].File > items[j].File
+					}
+					return items[i].File < items[j].File
+				}
+			case "line":
+				if items[i].Line != items[j].Line {
+					if key.Desc {
+						return items[i].Line > items[j].Line
+					}
+					return items[i].Line < items[j].Line
+				}
+			case "commit":
+				if items[i].Commit != items[j].Commit {
+					if key.Desc {
+						return items[i].Commit > items[j].Commit
+					}
+					return items[i].Commit < items[j].Commit
+				}
+			}
+		}
+		if items[i].File != items[j].File {
+			return items[i].File < items[j].File
+		}
+		return items[i].Line < items[j].Line
+	})
+}

--- a/internal/engine/types.go
+++ b/internal/engine/types.go
@@ -43,11 +43,12 @@ type Options struct {
 
 // Result は出力
 type Result struct {
-	Items      []Item      `json:"items"`
-	HasComment bool        `json:"has_comment"`
-	HasMessage bool        `json:"has_message"`
-	Total      int         `json:"total"`
-	ElapsedMS  int64       `json:"elapsed_ms"`
-	Errors     []ItemError `json:"errors,omitempty"`
-	ErrorCount int         `json:"error_count"`
+        Items      []Item      `json:"items"`
+        HasComment bool        `json:"has_comment"`
+        HasMessage bool        `json:"has_message"`
+        HasAge     bool        `json:"has_age"`
+        Total      int         `json:"total"`
+        ElapsedMS  int64       `json:"elapsed_ms"`
+        Errors     []ItemError `json:"errors,omitempty"`
+        ErrorCount int         `json:"error_count"`
 }


### PR DESCRIPTION
## Summary
- add reusable sort specification parsing and stable sorter shared by CLI and API
- introduce column field selection logic that cooperates with legacy --with-* flags and updates table/TSV rendering
- extend /api/scan and web UI to honor sort/field parameters and expose has_age metadata

## Testing
- go test ./...

------
https://chatgpt.com/codex/tasks/task_e_68d814d318148320a623ef76088776c7