### PR TITLE
Implement unified sorting and field selection

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -101,6 +101,7 @@ make build
 ### 出力形式
 
 - `-o, --output {table|tsv|json}` : 出力フォーマット（既定: table）
+- `--fields type,author,...` : table / TSV の列をカンマ区切りで指定（`--with-*` より優先）
 
 > JSON 出力には常に `age_days` フィールドが含まれます。
 
@@ -120,7 +121,7 @@ make build
 
 ### 並び替え
 
-- `--sort -age` : 最も古い TODO/FIXME を優先表示（同値はファイル名+行番号で安定ソート）
+- `--sort キー[,キー...]` : カンマ区切りで複数キーを指定（例: `-age,file,line`）。使用可能キー: `age`, `age_days`, `date`, `author`, `email`, `type`, `file`, `line`, `commit`, `location`。
 
 ### 進捗・ blame の振る舞い
 

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ make build
 ### Output selection
 
 - `-o, --output {table|tsv|json}`: choose the output format (default: table)
+- `--fields type,author,...`: choose table/TSV columns (comma separated). Overrides `--with-*` flags.
 
 > JSON output always includes an `age_days` field for each item.
 
@@ -119,7 +120,7 @@ make build
 
 ### Sorting
 
-- `--sort -age`: prioritize the oldest TODO/FIXME items (fallback to file/line order)
+- `--sort KEYS`: comma-separated sort keys (e.g. `-age,file,line`). Supported keys: `age`, `age_days`, `date`, `author`, `email`, `type`, `file`, `line`, `commit`, `location`.
 
 ### Progress / blame behaviour
 

--- a/cmd/todox/flags_test.go
+++ b/cmd/todox/flags_test.go
@@ -94,9 +94,9 @@ func TestParseScanArgsWithAgeAndSort(t *testing.T) {
 	}
 }
 
-func TestParseScanArgsRejectsUnknownSort(t *testing.T) {
-	if _, err := parseScanArgs([]string{"--sort", "author"}, "en"); err == nil {
-		t.Fatal("expected error for unsupported --sort value")
+func TestParseSortSpecRejectsUnknownKey(t *testing.T) {
+	if _, err := ParseSortSpec("-unknown"); err == nil {
+		t.Fatal("未知キーに対するエラーを期待しました")
 	}
 }
 

--- a/cmd/todox/sortspec.go
+++ b/cmd/todox/sortspec.go
@@ -1,0 +1,299 @@
+package main
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/example/todox/internal/engine"
+)
+
+// SortKey は単一カラムのソート条件を表します。
+type SortKey struct {
+	Name string
+	Desc bool
+}
+
+// SortSpec はソート条件の並びを表します。
+type SortSpec struct {
+	Keys []SortKey
+}
+
+var sortKeyAliases = map[string]string{
+	"age":      "age",
+	"age_days": "age",
+	"date":     "date",
+	"author":   "author",
+	"email":    "email",
+	"type":     "type",
+	"file":     "file",
+	"line":     "line",
+	"commit":   "commit",
+	"location": "location",
+}
+
+// ParseSortSpec は --sort / ?sort パラメータを解析し、内部ソート仕様を返します。
+func ParseSortSpec(raw string) (SortSpec, error) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return SortSpec{}, nil
+	}
+
+	parts := strings.Split(trimmed, ",")
+	spec := SortSpec{}
+	for _, part := range parts {
+		token := strings.TrimSpace(part)
+		if token == "" {
+			return SortSpec{}, fmt.Errorf("invalid sort spec: empty key")
+		}
+		desc := false
+		switch token[0] {
+		case '+':
+			token = token[1:]
+		case '-':
+			desc = true
+			token = token[1:]
+		}
+		if token == "" {
+			return SortSpec{}, fmt.Errorf("invalid sort spec: empty key")
+		}
+		canonical, ok := sortKeyAliases[token]
+		if !ok {
+			return SortSpec{}, fmt.Errorf("unknown sort key: %s", token)
+		}
+		switch canonical {
+		case "date":
+			spec.Keys = append(spec.Keys, SortKey{Name: "age", Desc: !desc})
+		case "location":
+			spec.Keys = append(spec.Keys,
+				SortKey{Name: "file", Desc: desc},
+				SortKey{Name: "line", Desc: desc},
+			)
+		default:
+			spec.Keys = append(spec.Keys, SortKey{Name: canonical, Desc: desc})
+		}
+	}
+	return spec, nil
+}
+
+// ApplySort は与えられた items を spec に従って安定ソートします。
+func ApplySort(items []engine.Item, spec SortSpec) {
+	if len(items) == 0 || len(spec.Keys) == 0 {
+		// エンジン側は file/line 順で返すため、キーが無ければそのまま利用する。
+		return
+	}
+	sort.SliceStable(items, func(i, j int) bool {
+		for _, key := range spec.Keys {
+			switch key.Name {
+			case "age":
+				if items[i].AgeDays != items[j].AgeDays {
+					if key.Desc {
+						return items[i].AgeDays > items[j].AgeDays
+					}
+					return items[i].AgeDays < items[j].AgeDays
+				}
+			case "author":
+				if items[i].Author != items[j].Author {
+					if key.Desc {
+						return items[i].Author > items[j].Author
+					}
+					return items[i].Author < items[j].Author
+				}
+			case "email":
+				if items[i].Email != items[j].Email {
+					if key.Desc {
+						return items[i].Email > items[j].Email
+					}
+					return items[i].Email < items[j].Email
+				}
+			case "type":
+				if items[i].Kind != items[j].Kind {
+					if key.Desc {
+						return items[i].Kind > items[j].Kind
+					}
+					return items[i].Kind < items[j].Kind
+				}
+			case "file":
+				if items[i].File != items[j].File {
+					if key.Desc {
+						return items[i].File > items[j].File
+					}
+					return items[i].File < items[j].File
+				}
+			case "line":
+				if items[i].Line != items[j].Line {
+					if key.Desc {
+						return items[i].Line > items[j].Line
+					}
+					return items[i].Line < items[j].Line
+				}
+			case "commit":
+				if items[i].Commit != items[j].Commit {
+					if key.Desc {
+						return items[i].Commit > items[j].Commit
+					}
+					return items[i].Commit < items[j].Commit
+				}
+			}
+		}
+		if items[i].File != items[j].File {
+			return items[i].File < items[j].File
+		}
+		return items[i].Line < items[j].Line
+	})
+}
+
+// DisplayField は table / TSV 向けの表示列定義。
+type DisplayField struct {
+	Name   string
+	Header string
+	Value  func(engine.Item) string
+}
+
+// FieldSelection は列選択結果と補助フラグを表す。
+type FieldSelection struct {
+	Fields     []DisplayField
+	HasComment bool
+	HasMessage bool
+	HasAge     bool
+}
+
+var fieldDefinitions = map[string]DisplayField{
+	"type": {
+		Name:   "type",
+		Header: "TYPE",
+		Value: func(it engine.Item) string {
+			return it.Kind
+		},
+	},
+	"author": {
+		Name:   "author",
+		Header: "AUTHOR",
+		Value: func(it engine.Item) string {
+			return it.Author
+		},
+	},
+	"email": {
+		Name:   "email",
+		Header: "EMAIL",
+		Value: func(it engine.Item) string {
+			return it.Email
+		},
+	},
+	"date": {
+		Name:   "date",
+		Header: "DATE",
+		Value: func(it engine.Item) string {
+			return it.Date
+		},
+	},
+	"age": {
+		Name:   "age",
+		Header: "AGE",
+		Value: func(it engine.Item) string {
+			return fmt.Sprintf("%d", it.AgeDays)
+		},
+	},
+	"commit": {
+		Name:   "commit",
+		Header: "COMMIT",
+		Value: func(it engine.Item) string {
+			return short(it.Commit)
+		},
+	},
+	"location": {
+		Name:   "location",
+		Header: "LOCATION",
+		Value: func(it engine.Item) string {
+			return fmt.Sprintf("%s:%d", it.File, it.Line)
+		},
+	},
+	"comment": {
+		Name:   "comment",
+		Header: "COMMENT",
+		Value: func(it engine.Item) string {
+			return it.Comment
+		},
+	},
+	"message": {
+		Name:   "message",
+		Header: "MESSAGE",
+		Value: func(it engine.Item) string {
+			return it.Message
+		},
+	},
+}
+
+var validFieldNames = map[string]struct{}{
+	"type":     {},
+	"author":   {},
+	"email":    {},
+	"date":     {},
+	"age":      {},
+	"commit":   {},
+	"location": {},
+	"comment":  {},
+	"message":  {},
+}
+
+// ResolveFields は表示フィールド指定と互換フラグから最終的な列構成を決定します。
+func ResolveFields(raw string, withComment, withMessage, withAge bool) (FieldSelection, error) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		fields := []DisplayField{
+			fieldDefinitions["type"],
+			fieldDefinitions["author"],
+			fieldDefinitions["email"],
+			fieldDefinitions["date"],
+		}
+		if withAge {
+			fields = append(fields, fieldDefinitions["age"])
+		}
+		fields = append(fields,
+			fieldDefinitions["commit"],
+			fieldDefinitions["location"],
+		)
+		if withComment {
+			fields = append(fields, fieldDefinitions["comment"])
+		}
+		if withMessage {
+			fields = append(fields, fieldDefinitions["message"])
+		}
+		return FieldSelection{
+			Fields:     fields,
+			HasComment: withComment,
+			HasMessage: withMessage,
+			HasAge:     withAge,
+		}, nil
+	}
+
+	parts := strings.Split(trimmed, ",")
+	seen := map[string]bool{}
+	fields := make([]DisplayField, 0, len(parts))
+	sel := FieldSelection{}
+	for _, part := range parts {
+		name := strings.TrimSpace(part)
+		if name == "" {
+			return FieldSelection{}, fmt.Errorf("invalid fields spec: empty value")
+		}
+		if _, ok := validFieldNames[name]; !ok {
+			return FieldSelection{}, fmt.Errorf("unknown field: %s", name)
+		}
+		if seen[name] {
+			continue
+		}
+		seen[name] = true
+		def := fieldDefinitions[name]
+		fields = append(fields, def)
+		switch name {
+		case "comment":
+			sel.HasComment = true
+		case "message":
+			sel.HasMessage = true
+		case "age":
+			sel.HasAge = true
+		}
+	}
+	sel.Fields = fields
+	return sel, nil
+}

--- a/cmd/todox/sortspec_test.go
+++ b/cmd/todox/sortspec_test.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/example/todox/internal/engine"
+)
+
+func TestParseSortSpec複合キーを展開する(t *testing.T) {
+	spec, err := ParseSortSpec("author,-date,location")
+	if err != nil {
+		t.Fatalf("ParseSortSpec に失敗しました: %v", err)
+	}
+	want := []SortKey{{Name: "author", Desc: false}, {Name: "age", Desc: false}, {Name: "file", Desc: false}, {Name: "line", Desc: false}}
+	if len(spec.Keys) != len(want) {
+		t.Fatalf("キー数が一致しません: got=%d want=%d", len(spec.Keys), len(want))
+	}
+	for i, k := range spec.Keys {
+		if k != want[i] {
+			t.Fatalf("キーが一致しません: index=%d got=%+v want=%+v", i, k, want[i])
+		}
+	}
+}
+
+func TestApplySortはlocationを考慮する(t *testing.T) {
+	items := []engine.Item{{File: "b.go", Line: 20}, {File: "a.go", Line: 30}, {File: "a.go", Line: 10}}
+	spec, err := ParseSortSpec("location")
+	if err != nil {
+		t.Fatalf("ParseSortSpec に失敗しました: %v", err)
+	}
+	ApplySort(items, spec)
+	if items[0].File != "a.go" || items[0].Line != 10 {
+		t.Fatalf("location ソートが期待通りではありません: %+v", items)
+	}
+	if items[1].File != "a.go" || items[1].Line != 30 {
+		t.Fatalf("2番目の項目が期待通りではありません: %+v", items)
+	}
+}
+
+func TestResolveFields既定値(t *testing.T) {
+	sel, err := ResolveFields("", true, false, true)
+	if err != nil {
+		t.Fatalf("ResolveFields に失敗しました: %v", err)
+	}
+	if !sel.HasComment || sel.HasMessage || !sel.HasAge {
+		t.Fatalf("既定のフラグ解釈が期待通りではありません: %+v", sel)
+	}
+	gotHeaders := make([]string, len(sel.Fields))
+	for i, f := range sel.Fields {
+		gotHeaders[i] = f.Header
+	}
+	want := []string{"TYPE", "AUTHOR", "EMAIL", "DATE", "AGE", "COMMIT", "LOCATION", "COMMENT"}
+	if len(gotHeaders) != len(want) {
+		t.Fatalf("ヘッダー数が一致しません: got=%v want=%v", gotHeaders, want)
+	}
+	for i := range want {
+		if gotHeaders[i] != want[i] {
+			t.Fatalf("ヘッダー順が一致しません: index=%d got=%s want=%s", i, gotHeaders[i], want[i])
+		}
+	}
+}
+
+func TestResolveFields任意指定(t *testing.T) {
+	sel, err := ResolveFields("type,author,date,age,location", false, false, false)
+	if err != nil {
+		t.Fatalf("ResolveFields に失敗しました: %v", err)
+	}
+	if !sel.HasAge {
+		t.Fatal("age を指定した場合は HasAge が真になるはずです")
+	}
+	if sel.HasComment || sel.HasMessage {
+		t.Fatalf("comment/message を含まない場合は false のはずです: %+v", sel)
+	}
+	if len(sel.Fields) != 5 {
+		t.Fatalf("列数が一致しません: %d", len(sel.Fields))
+	}
+	if sel.Fields[3].Name != "age" {
+		t.Fatalf("age 列の位置が期待と異なります: %+v", sel.Fields)
+	}
+}
+
+func TestResolveFields未知値はエラー(t *testing.T) {
+	if _, err := ResolveFields("type,unknown", false, false, false); err == nil {
+		t.Fatal("未知のフィールドでエラーを期待しました")
+	}
+}

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -58,7 +58,7 @@ func Run(opts Options) (*Result, error) {
 		return nil, err
 	}
 	if len(matches) == 0 {
-		return &Result{Items: nil, HasComment: opts.WithComment, HasMessage: opts.WithMessage, Total: 0, ElapsedMS: msSince(start)}, nil
+		return &Result{Items: nil, HasComment: opts.WithComment, HasMessage: opts.WithMessage, HasAge: false, Total: 0, ElapsedMS: msSince(start)}, nil
 	}
 
 	// filter by TYPE precisely (for lines containing both)
@@ -167,6 +167,7 @@ func Run(opts Options) (*Result, error) {
 		Items:      final,
 		HasComment: opts.WithComment,
 		HasMessage: opts.WithMessage,
+		HasAge:     false,
 		Total:      len(final),
 		ElapsedMS:  msSince(start),
 		Errors:     errs,

--- a/internal/engine/types.go
+++ b/internal/engine/types.go
@@ -46,6 +46,7 @@ type Result struct {
 	Items      []Item      `json:"items"`
 	HasComment bool        `json:"has_comment"`
 	HasMessage bool        `json:"has_message"`
+	HasAge     bool        `json:"has_age"`
 	Total      int         `json:"total"`
 	ElapsedMS  int64       `json:"elapsed_ms"`
 	Errors     []ItemError `json:"errors,omitempty"`


### PR DESCRIPTION
## Summary
- add a shared sort/field specification parser so CLI and /api/scan support the same sorting semantics
- allow table/TSV output to be customized via --fields/fields and align Has* flags for clients, updating help text and docs
- expose has_age to the web UI and show the AGE column when requested while keeping JSON output compatible

## Testing
- go test ./...

------
https://chatgpt.com/codex/tasks/task_e_68d814d318148320a623ef76088776c7