### PR TITLE
Implement unified sorting and field selection across CLI and API

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -101,6 +101,7 @@ make build
 ### 出力形式
 
 - `-o, --output {table|tsv|json}` : 出力フォーマット（既定: table）
+- `--fields type,author,date,...` : table/TSV の列順を指定（カンマ区切り。`--with-*` より優先）
 
 > JSON 出力には常に `age_days` フィールドが含まれます。
 
@@ -120,7 +121,8 @@ make build
 
 ### 並び替え
 
-- `--sort -age` : 最も古い TODO/FIXME を優先表示（同値はファイル名+行番号で安定ソート）
+- `--sort key[,key...]` : 多段ソート。`-` で降順、`+`（または省略）で昇順を指定。
+  利用可能キー: `age`, `date`, `author`, `email`, `type`, `file`, `line`, `commit`, `location`（`file,line`）。
 
 ### 進捗・ blame の振る舞い
 

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ make build
 ### Output selection
 
 - `-o, --output {table|tsv|json}`: choose the output format (default: table)
+- `--fields type,author,date,...`: choose the columns for table/TSV (comma separated; overrides `--with-*`)
 
 > JSON output always includes an `age_days` field for each item.
 
@@ -119,7 +120,8 @@ make build
 
 ### Sorting
 
-- `--sort -age`: prioritize the oldest TODO/FIXME items (fallback to file/line order)
+- `--sort key[,key...]`: multi-level sort. Prefix with `-` for descending, `+` (or nothing) for ascending.
+  Supported keys: `age`, `date`, `author`, `email`, `type`, `file`, `line`, `commit`, `location` (`file,line`).
 
 ### Progress / blame behaviour
 

--- a/cmd/todox/fields.go
+++ b/cmd/todox/fields.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/example/todox/internal/engine"
+)
+
+type Field struct {
+	Key    string
+	Header string
+}
+
+type FieldSelection struct {
+	Fields      []Field
+	ShowAge     bool
+	ShowComment bool
+	ShowMessage bool
+	NeedComment bool
+	NeedMessage bool
+}
+
+type fieldMeta struct {
+	header    string
+	isAge     bool
+	isComment bool
+	isMessage bool
+}
+
+var fieldRegistry = map[string]fieldMeta{
+	"type":     {header: "TYPE"},
+	"author":   {header: "AUTHOR"},
+	"email":    {header: "EMAIL"},
+	"date":     {header: "DATE"},
+	"age":      {header: "AGE", isAge: true},
+	"commit":   {header: "COMMIT"},
+	"location": {header: "LOCATION"},
+	"comment":  {header: "COMMENT", isComment: true},
+	"message":  {header: "MESSAGE", isMessage: true},
+}
+
+func ResolveFields(raw string, withComment, withMessage, withAge bool) (FieldSelection, error) {
+	raw = strings.TrimSpace(raw)
+	sel := FieldSelection{}
+	if raw == "" {
+		keys := []string{"type", "author", "email", "date"}
+		if withAge {
+			keys = append(keys, "age")
+		}
+		keys = append(keys, "commit", "location")
+		if withComment {
+			keys = append(keys, "comment")
+		}
+		if withMessage {
+			keys = append(keys, "message")
+		}
+		sel.Fields = make([]Field, 0, len(keys))
+		for _, key := range keys {
+			meta := fieldRegistry[key]
+			sel.Fields = append(sel.Fields, Field{Key: key, Header: meta.header})
+		}
+		sel.ShowAge = withAge
+		sel.ShowComment = withComment
+		sel.ShowMessage = withMessage
+		sel.NeedComment = withComment
+		sel.NeedMessage = withMessage
+		return sel, nil
+	}
+
+	parts := strings.Split(raw, ",")
+	sel.Fields = make([]Field, 0, len(parts))
+	for _, part := range parts {
+		name := strings.TrimSpace(part)
+		if name == "" {
+			return FieldSelection{}, fmt.Errorf("invalid fields: empty entry")
+		}
+		key := strings.ToLower(name)
+		meta, ok := fieldRegistry[key]
+		if !ok {
+			return FieldSelection{}, fmt.Errorf("unknown field: %s", name)
+		}
+		sel.Fields = append(sel.Fields, Field{Key: key, Header: meta.header})
+		if meta.isAge {
+			sel.ShowAge = true
+		}
+		if meta.isComment {
+			sel.ShowComment = true
+		}
+		if meta.isMessage {
+			sel.ShowMessage = true
+		}
+	}
+	sel.NeedComment = withComment || sel.ShowComment
+	sel.NeedMessage = withMessage || sel.ShowMessage
+	return sel, nil
+}
+
+func formatFieldValue(it engine.Item, key string) string {
+	switch key {
+	case "type":
+		return it.Kind
+	case "author":
+		return it.Author
+	case "email":
+		return it.Email
+	case "date":
+		return it.Date
+	case "age":
+		return strconv.Itoa(it.AgeDays)
+	case "commit":
+		return short(it.Commit)
+	case "location":
+		return fmt.Sprintf("%s:%d", it.File, it.Line)
+	case "comment":
+		return it.Comment
+	case "message":
+		return it.Message
+	default:
+		return ""
+	}
+}

--- a/cmd/todox/fields_test.go
+++ b/cmd/todox/fields_test.go
@@ -1,0 +1,57 @@
+package main
+
+import "testing"
+
+func TestResolveFieldsDefaultUsesFlags(t *testing.T) {
+	sel, err := ResolveFields("", true, false, true)
+	if err != nil {
+		t.Fatalf("ResolveFields failed: %v", err)
+	}
+	headers := []string{"TYPE", "AUTHOR", "EMAIL", "DATE", "AGE", "COMMIT", "LOCATION", "COMMENT"}
+	if len(sel.Fields) != len(headers) {
+		t.Fatalf("field count mismatch: got=%d want=%d", len(sel.Fields), len(headers))
+	}
+	for i, f := range sel.Fields {
+		if f.Header != headers[i] {
+			t.Fatalf("header %d mismatch: got=%s want=%s", i, f.Header, headers[i])
+		}
+	}
+	if !sel.ShowAge || !sel.ShowComment || sel.ShowMessage {
+		t.Fatalf("show flags mismatch: %+v", sel)
+	}
+	if !sel.NeedComment || sel.NeedMessage {
+		t.Fatalf("need flags mismatch: %+v", sel)
+	}
+}
+
+func TestResolveFieldsOverridesFlags(t *testing.T) {
+	sel, err := ResolveFields("type,author", true, true, false)
+	if err != nil {
+		t.Fatalf("ResolveFields failed: %v", err)
+	}
+	if sel.ShowComment {
+		t.Fatal("comment column should be disabled when fields override")
+	}
+	if !sel.NeedComment || !sel.NeedMessage {
+		t.Fatalf("need flags should respect original requests: %+v", sel)
+	}
+	if len(sel.Fields) != 2 || sel.Fields[0].Key != "type" || sel.Fields[1].Key != "author" {
+		t.Fatalf("fields mismatch: %+v", sel.Fields)
+	}
+}
+
+func TestResolveFieldsEnablesMessageViaFields(t *testing.T) {
+	sel, err := ResolveFields("type,message", false, false, false)
+	if err != nil {
+		t.Fatalf("ResolveFields failed: %v", err)
+	}
+	if !sel.ShowMessage || !sel.NeedMessage {
+		t.Fatalf("message flags not set: %+v", sel)
+	}
+}
+
+func TestResolveFieldsUnknownField(t *testing.T) {
+	if _, err := ResolveFields("unknown", false, false, false); err == nil {
+		t.Fatal("expected error for unknown field")
+	}
+}

--- a/cmd/todox/flags_test.go
+++ b/cmd/todox/flags_test.go
@@ -94,9 +94,13 @@ func TestParseScanArgsWithAgeAndSort(t *testing.T) {
 	}
 }
 
-func TestParseScanArgsRejectsUnknownSort(t *testing.T) {
-	if _, err := parseScanArgs([]string{"--sort", "author"}, "en"); err == nil {
-		t.Fatal("expected error for unsupported --sort value")
+func TestParseScanArgsFieldsFlag(t *testing.T) {
+	cfg, err := parseScanArgs([]string{"--fields", "type,author,date"}, "en")
+	if err != nil {
+		t.Fatalf("parseScanArgs failed: %v", err)
+	}
+	if cfg.fields != "type,author,date" {
+		t.Fatalf("fields flag not captured: %q", cfg.fields)
 	}
 }
 

--- a/cmd/todox/sortspec.go
+++ b/cmd/todox/sortspec.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/example/todox/internal/engine"
+)
+
+type SortKey struct {
+	Name string
+	Desc bool
+}
+
+type SortSpec struct {
+	Keys []SortKey
+}
+
+func ParseSortSpec(raw string) (SortSpec, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return SortSpec{}, nil
+	}
+	parts := strings.Split(raw, ",")
+	keys := make([]SortKey, 0, len(parts))
+	for _, part := range parts {
+		token := strings.TrimSpace(part)
+		if token == "" {
+			return SortSpec{}, fmt.Errorf("invalid sort spec: empty key")
+		}
+		desc := false
+		if strings.HasPrefix(token, "-") || strings.HasPrefix(token, "+") {
+			desc = strings.HasPrefix(token, "-")
+			token = strings.TrimSpace(token[1:])
+			if token == "" {
+				return SortSpec{}, fmt.Errorf("invalid sort spec: empty key")
+			}
+		}
+		name := strings.ToLower(token)
+		switch name {
+		case "age", "age_days":
+			name = "age"
+		case "date":
+			name = "age"
+			desc = !desc
+		case "author", "email", "type", "file", "line", "commit":
+			// accepted as-is
+		case "location":
+			keys = append(keys, SortKey{Name: "file", Desc: desc}, SortKey{Name: "line", Desc: desc})
+			continue
+		default:
+			return SortSpec{}, fmt.Errorf("unknown sort key: %s", token)
+		}
+		keys = append(keys, SortKey{Name: name, Desc: desc})
+	}
+	return SortSpec{Keys: keys}, nil
+}
+
+func ApplySort(items []engine.Item, spec SortSpec) {
+	if len(spec.Keys) == 0 {
+		return
+	}
+	sort.SliceStable(items, func(i, j int) bool {
+		left := items[i]
+		right := items[j]
+		for _, key := range spec.Keys {
+			switch key.Name {
+			case "age":
+				if left.AgeDays != right.AgeDays {
+					if key.Desc {
+						return left.AgeDays > right.AgeDays
+					}
+					return left.AgeDays < right.AgeDays
+				}
+			case "author":
+				if left.Author != right.Author {
+					if key.Desc {
+						return left.Author > right.Author
+					}
+					return left.Author < right.Author
+				}
+			case "email":
+				if left.Email != right.Email {
+					if key.Desc {
+						return left.Email > right.Email
+					}
+					return left.Email < right.Email
+				}
+			case "type":
+				if left.Kind != right.Kind {
+					if key.Desc {
+						return left.Kind > right.Kind
+					}
+					return left.Kind < right.Kind
+				}
+			case "file":
+				if left.File != right.File {
+					if key.Desc {
+						return left.File > right.File
+					}
+					return left.File < right.File
+				}
+			case "line":
+				if left.Line != right.Line {
+					if key.Desc {
+						return left.Line > right.Line
+					}
+					return left.Line < right.Line
+				}
+			case "commit":
+				if left.Commit != right.Commit {
+					if key.Desc {
+						return left.Commit > right.Commit
+					}
+					return left.Commit < right.Commit
+				}
+			}
+		}
+		if left.File != right.File {
+			return left.File < right.File
+		}
+		return left.Line < right.Line
+	})
+}

--- a/cmd/todox/sortspec_test.go
+++ b/cmd/todox/sortspec_test.go
@@ -1,0 +1,37 @@
+package main
+
+import "testing"
+
+func TestParseSortSpecNormalizesKeys(t *testing.T) {
+	spec, err := ParseSortSpec("author,-date,location,age_days")
+	if err != nil {
+		t.Fatalf("ParseSortSpec failed: %v", err)
+	}
+	want := []SortKey{
+		{Name: "author", Desc: false},
+		{Name: "age", Desc: false},
+		{Name: "file", Desc: false},
+		{Name: "line", Desc: false},
+		{Name: "age", Desc: false},
+	}
+	if len(spec.Keys) != len(want) {
+		t.Fatalf("unexpected key count: got=%v want=%v", spec.Keys, want)
+	}
+	for i, got := range spec.Keys {
+		if got != want[i] {
+			t.Fatalf("key %d mismatch: got=%+v want=%+v", i, got, want[i])
+		}
+	}
+}
+
+func TestParseSortSpecUnknownKey(t *testing.T) {
+	if _, err := ParseSortSpec("unknown"); err == nil {
+		t.Fatal("expected error for unknown sort key")
+	}
+}
+
+func TestParseSortSpecEmptyEntry(t *testing.T) {
+	if _, err := ParseSortSpec("author,,file"); err == nil {
+		t.Fatal("expected error for empty sort key")
+	}
+}

--- a/internal/engine/types.go
+++ b/internal/engine/types.go
@@ -46,6 +46,7 @@ type Result struct {
 	Items      []Item      `json:"items"`
 	HasComment bool        `json:"has_comment"`
 	HasMessage bool        `json:"has_message"`
+	HasAge     bool        `json:"has_age"`
 	Total      int         `json:"total"`
 	ElapsedMS  int64       `json:"elapsed_ms"`
 	Errors     []ItemError `json:"errors,omitempty"`


### PR DESCRIPTION
## Summary
- add shared helpers for parsing sort specifications and resolving column selections so CLI and API reuse the same logic
- extend the CLI with a --fields flag, multi-key --sort support, and update the API/web UI to honor the same sorting and column hints while exposing has_age
- refresh documentation/help text and add unit tests that cover sort parsing, field resolution, and new API error handling

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d814d318148320a623ef76088776c7