### PR TITLE
feat: add shared sort spec and field selection

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -59,7 +59,7 @@ make build
 ./bin/todox -a 'Alice|alice@example.com'
 
 # 最古の TODO/FIXME から順に表示し、AGE 列を追加
-./bin/todox --with-age --sort -age
+./bin/todox --fields type,author,date,age,location --sort -age,file,line
 
 # TSV / JSON で出力
 ./bin/todox --output tsv  > todo.tsv
@@ -106,6 +106,7 @@ make build
 
 ### 追加列（非表示が既定）
 
+- `--fields type,author,date,age,location` : table / TSV の列をカンマ区切りで指定（`--with-*` より優先）
 - `--with-comment` : TODO/FIXME 行を表示
 - `--with-snippet` : `--with-comment` のエイリアス（後方互換用途）
 - `--with-message` : コミットサマリ（1 行目）を表示
@@ -120,7 +121,7 @@ make build
 
 ### 並び替え
 
-- `--sort -age` : 最も古い TODO/FIXME を優先表示（同値はファイル名+行番号で安定ソート）
+- `--sort SPEC` : `--sort -age,file` のようにカンマ区切りで指定。利用可能なキー: `age`, `date`, `author`, `email`, `type`, `file`, `line`, `commit`, `location`
 
 ### 進捗・ blame の振る舞い
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ make build
 ./bin/todox -a 'Alice|alice@example.com'
 
 # Surface the stalest TODO/FIXME items first and display AGE in the output
-./bin/todox --with-age --sort -age
+./bin/todox --fields type,author,date,age,location --sort -age,file,line
 
 # Export as TSV or JSON
 ./bin/todox --output tsv  > todo.tsv
@@ -105,6 +105,7 @@ make build
 
 ### Extra columns (hidden by default)
 
+- `--fields type,author,date,age,location`: choose columns for table/TSV (comma-separated, overrides `--with-*`)
 - `--with-comment`: include the TODO/FIXME line text
 - `--with-snippet`: alias of `--with-comment` (kept for backward compatibility)
 - `--with-message`: include the commit subject (first line)
@@ -119,7 +120,7 @@ make build
 
 ### Sorting
 
-- `--sort -age`: prioritize the oldest TODO/FIXME items (fallback to file/line order)
+- `--sort SPEC`: comma-separated keys such as `--sort -age,file`. Supported keys: `age`, `date`, `author`, `email`, `type`, `file`, `line`, `commit`, `location`
 
 ### Progress / blame behaviour
 

--- a/cmd/todox/fields.go
+++ b/cmd/todox/fields.go
@@ -1,0 +1,134 @@
+package main
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/example/todox/internal/engine"
+)
+
+type FieldName string
+
+const (
+	FieldType     FieldName = "type"
+	FieldAuthor   FieldName = "author"
+	FieldEmail    FieldName = "email"
+	FieldDate     FieldName = "date"
+	FieldAge      FieldName = "age"
+	FieldCommit   FieldName = "commit"
+	FieldLocation FieldName = "location"
+	FieldComment  FieldName = "comment"
+	FieldMessage  FieldName = "message"
+)
+
+type FieldLayout struct {
+	Fields      []FieldName
+	ShowComment bool
+	ShowMessage bool
+	ShowAge     bool
+}
+
+var allowedFields = map[string]FieldName{
+	"type":     FieldType,
+	"author":   FieldAuthor,
+	"email":    FieldEmail,
+	"date":     FieldDate,
+	"age":      FieldAge,
+	"commit":   FieldCommit,
+	"location": FieldLocation,
+	"comment":  FieldComment,
+	"message":  FieldMessage,
+}
+
+func resolveFields(raw string, withComment, withMessage, withAge bool) (FieldLayout, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		fields := []FieldName{FieldType, FieldAuthor, FieldEmail, FieldDate}
+		if withAge {
+			fields = append(fields, FieldAge)
+		}
+		fields = append(fields, FieldCommit, FieldLocation)
+		if withComment {
+			fields = append(fields, FieldComment)
+		}
+		if withMessage {
+			fields = append(fields, FieldMessage)
+		}
+		return FieldLayout{Fields: fields, ShowComment: withComment, ShowMessage: withMessage, ShowAge: withAge}, nil
+	}
+
+	parts := strings.Split(raw, ",")
+	fields := make([]FieldName, 0, len(parts))
+	var showComment, showMessage, showAge bool
+	for _, part := range parts {
+		token := strings.ToLower(strings.TrimSpace(part))
+		if token == "" {
+			return FieldLayout{}, fmt.Errorf("invalid field: empty segment")
+		}
+		field, ok := allowedFields[token]
+		if !ok {
+			return FieldLayout{}, fmt.Errorf("invalid field: %s", token)
+		}
+		fields = append(fields, field)
+		switch field {
+		case FieldComment:
+			showComment = true
+		case FieldMessage:
+			showMessage = true
+		case FieldAge:
+			showAge = true
+		}
+	}
+	return FieldLayout{Fields: fields, ShowComment: showComment, ShowMessage: showMessage, ShowAge: showAge}, nil
+}
+
+func fieldHeader(name FieldName) string {
+	switch name {
+	case FieldType:
+		return "TYPE"
+	case FieldAuthor:
+		return "AUTHOR"
+	case FieldEmail:
+		return "EMAIL"
+	case FieldDate:
+		return "DATE"
+	case FieldAge:
+		return "AGE"
+	case FieldCommit:
+		return "COMMIT"
+	case FieldLocation:
+		return "LOCATION"
+	case FieldComment:
+		return "COMMENT"
+	case FieldMessage:
+		return "MESSAGE"
+	default:
+		return strings.ToUpper(string(name))
+	}
+}
+
+func fieldValue(it engine.Item, field FieldName) string {
+	switch field {
+	case FieldType:
+		return it.Kind
+	case FieldAuthor:
+		return it.Author
+	case FieldEmail:
+		return it.Email
+	case FieldDate:
+		return it.Date
+	case FieldAge:
+		return strconv.Itoa(it.AgeDays)
+	case FieldCommit:
+		return short(it.Commit)
+	case FieldLocation:
+		return fmt.Sprintf("%s:%d", it.File, it.Line)
+	case FieldComment:
+		return it.Comment
+	case FieldMessage:
+		return it.Message
+	default:
+		return ""
+	}
+}

--- a/cmd/todox/flags_test.go
+++ b/cmd/todox/flags_test.go
@@ -94,9 +94,16 @@ func TestParseScanArgsWithAgeAndSort(t *testing.T) {
 	}
 }
 
-func TestParseScanArgsRejectsUnknownSort(t *testing.T) {
-	if _, err := parseScanArgs([]string{"--sort", "author"}, "en"); err == nil {
-		t.Fatal("expected error for unsupported --sort value")
+func TestParseScanArgsStoresFields(t *testing.T) {
+	cfg, err := parseScanArgs([]string{"--fields", "type,comment"}, "en")
+	if err != nil {
+		t.Fatalf("parseScanArgs failed: %v", err)
+	}
+	if cfg.fields != "type,comment" {
+		t.Fatalf("fields mismatch: got %q", cfg.fields)
+	}
+	if cfg.withComment {
+		t.Fatalf("withComment should remain false until resolved")
 	}
 }
 

--- a/cmd/todox/sortspec.go
+++ b/cmd/todox/sortspec.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/example/todox/internal/engine"
+)
+
+type SortKey struct {
+	Name string
+	Desc bool
+}
+
+type SortSpec struct {
+	Keys []SortKey
+}
+
+func ParseSortSpec(raw string) (SortSpec, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return SortSpec{}, nil
+	}
+	parts := strings.Split(raw, ",")
+	keys := make([]SortKey, 0, len(parts))
+	for _, part := range parts {
+		token := strings.TrimSpace(part)
+		if token == "" {
+			return SortSpec{}, fmt.Errorf("invalid sort key: empty segment")
+		}
+		desc := false
+		switch token[0] {
+		case '+':
+			token = token[1:]
+		case '-':
+			desc = true
+			token = token[1:]
+		}
+		token = strings.TrimSpace(token)
+		if token == "" {
+			return SortSpec{}, fmt.Errorf("invalid sort key: sign without name")
+		}
+		name := strings.ToLower(token)
+		switch name {
+		case "age_days":
+			name = "age"
+		case "date":
+			desc = !desc
+			name = "age"
+		case "location":
+			keys = append(keys, SortKey{Name: "file", Desc: desc}, SortKey{Name: "line", Desc: desc})
+			continue
+		case "age", "author", "email", "type", "file", "line", "commit":
+			// accepted as is
+		default:
+			return SortSpec{}, fmt.Errorf("invalid sort key: %s", token)
+		}
+		keys = append(keys, SortKey{Name: name, Desc: desc})
+	}
+	return SortSpec{Keys: keys}, nil
+}
+
+func ApplySort(items []engine.Item, spec SortSpec) {
+	keys := spec.Keys
+	if len(keys) == 0 {
+		keys = []SortKey{{Name: "file"}, {Name: "line"}}
+	} else {
+		keys = append(append([]SortKey{}, keys...), SortKey{Name: "file"}, SortKey{Name: "line"})
+	}
+	sort.SliceStable(items, func(i, j int) bool {
+		a := &items[i]
+		b := &items[j]
+		for _, key := range keys {
+			switch key.Name {
+			case "age":
+				if a.AgeDays != b.AgeDays {
+					if key.Desc {
+						return a.AgeDays > b.AgeDays
+					}
+					return a.AgeDays < b.AgeDays
+				}
+			case "author":
+				if a.Author != b.Author {
+					if key.Desc {
+						return a.Author > b.Author
+					}
+					return a.Author < b.Author
+				}
+			case "email":
+				if a.Email != b.Email {
+					if key.Desc {
+						return a.Email > b.Email
+					}
+					return a.Email < b.Email
+				}
+			case "type":
+				if a.Kind != b.Kind {
+					if key.Desc {
+						return a.Kind > b.Kind
+					}
+					return a.Kind < b.Kind
+				}
+			case "file":
+				if a.File != b.File {
+					if key.Desc {
+						return a.File > b.File
+					}
+					return a.File < b.File
+				}
+			case "line":
+				if a.Line != b.Line {
+					if key.Desc {
+						return a.Line > b.Line
+					}
+					return a.Line < b.Line
+				}
+			case "commit":
+				if a.Commit != b.Commit {
+					if key.Desc {
+						return a.Commit > b.Commit
+					}
+					return a.Commit < b.Commit
+				}
+			}
+		}
+		return false
+	})
+}

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -58,7 +58,7 @@ func Run(opts Options) (*Result, error) {
 		return nil, err
 	}
 	if len(matches) == 0 {
-		return &Result{Items: nil, HasComment: opts.WithComment, HasMessage: opts.WithMessage, Total: 0, ElapsedMS: msSince(start)}, nil
+		return &Result{Items: nil, HasComment: opts.WithComment, HasMessage: opts.WithMessage, HasAge: false, Total: 0, ElapsedMS: msSince(start)}, nil
 	}
 
 	// filter by TYPE precisely (for lines containing both)
@@ -167,6 +167,7 @@ func Run(opts Options) (*Result, error) {
 		Items:      final,
 		HasComment: opts.WithComment,
 		HasMessage: opts.WithMessage,
+		HasAge:     false,
 		Total:      len(final),
 		ElapsedMS:  msSince(start),
 		Errors:     errs,

--- a/internal/engine/types.go
+++ b/internal/engine/types.go
@@ -46,6 +46,7 @@ type Result struct {
 	Items      []Item      `json:"items"`
 	HasComment bool        `json:"has_comment"`
 	HasMessage bool        `json:"has_message"`
+	HasAge     bool        `json:"has_age"`
 	Total      int         `json:"total"`
 	ElapsedMS  int64       `json:"elapsed_ms"`
 	Errors     []ItemError `json:"errors,omitempty"`


### PR DESCRIPTION
## Summary
- add shared sort specification parsing and sorting used by both CLI and /api/scan
- introduce field layout resolution to harmonize table/TSV output and toggle age/comment/message columns
- expose has_age metadata to the API/UI and document the new --fields/--sort semantics

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d814d318148320a623ef76088776c7