### PR TITLE
Unify CLI and web option validation

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -105,6 +105,19 @@ make build
 
 > JSON 出力には常に `age_days` フィールドが含まれます。
 
+### 入力ルール（CLI / Web 共通）
+
+CLI フラグと `/api/scan` のクエリパラメータは同じ正規化レイヤで検証されます。
+
+| パラメータ | 受け入れ値 | 備考 |
+|-------------|-------------|------|
+| 真偽値トグル（`with_comment`, `with_message`, `with_age`, `ignore_ws` など） | `1`, `0`, `true`, `false`, `yes`, `no`, `on`, `off`（大文字小文字は不問） | 空文字は未指定として無視します。 |
+| `--type` / `type` | `todo`, `fixme`, `both` | 既定は `both`。 |
+| `--mode` / `mode` | `last`, `first` | 既定は `last`。 |
+| `--output` / `output` | `table`, `tsv`, `json` | 既定は `table`。 |
+| `--truncate*` / `truncate*` | 0 以上の整数 | 負の値はエラー。 |
+| `--jobs` / `jobs` | 1〜64 の整数 | 範囲外はエラー。 |
+
 ### 追加列（非表示が既定）
 
 - `--with-comment` : TODO/FIXME 行を表示

--- a/README.md
+++ b/README.md
@@ -104,6 +104,19 @@ make build
 
 > JSON output always includes an `age_days` field for each item.
 
+### Shared input rules (CLI & Web)
+
+Both the CLI flags and the `/api/scan` query parameters go through the same normalisation layer:
+
+| Parameter | Accepted values | Notes |
+|-----------|-----------------|-------|
+| Boolean toggles (`with_comment`, `with_message`, `with_age`, `ignore_ws`, etc.) | `1`, `0`, `true`, `false`, `yes`, `no`, `on`, `off` (case-insensitive) | Empty strings are ignored. |
+| `--type` / `type` | `todo`, `fixme`, `both` | Defaults to `both`. |
+| `--mode` / `mode` | `last`, `first` | Defaults to `last`. |
+| `--output` / `output` | `table`, `tsv`, `json` | Defaults to `table`. |
+| `--truncate*` / `truncate*` | `0` or greater integers | Negative numbers return an error. |
+| `--jobs` / `jobs` | Integers `1`–`64` | Values outside the range are rejected. |
+
 ### Extra columns (hidden by default)
 
 - `--with-comment`: include the TODO/FIXME line text

--- a/cmd/todox/flags_test.go
+++ b/cmd/todox/flags_test.go
@@ -104,6 +104,18 @@ func TestParseScanArgsFieldsFlag(t *testing.T) {
 	}
 }
 
+func TestParseScanArgsRejectsInvalidType(t *testing.T) {
+	if _, err := parseScanArgs([]string{"--type", "unknown"}, "en"); err == nil {
+		t.Fatal("parseScanArgs should fail for invalid --type")
+	}
+}
+
+func TestParseScanArgsRejectsInvalidOutput(t *testing.T) {
+	if _, err := parseScanArgs([]string{"--output", "csv"}, "en"); err == nil {
+		t.Fatal("parseScanArgs should fail for invalid --output")
+	}
+}
+
 func TestHelpOutputEnglish(t *testing.T) {
 	output := runTodox(t, "-h")
 	if !strings.Contains(output, "todox — Find who wrote TODO/FIXME") {

--- a/cmd/todox/main_test.go
+++ b/cmd/todox/main_test.go
@@ -284,100 +284,6 @@ func TestReportErrorsは標準エラーに概要を出力する(t *testing.T) {
 	}
 }
 
-func TestParseBoolParamは受け入れ値を解釈する(t *testing.T) {
-	t.Parallel()
-
-	cases := map[string]struct {
-		value   string
-		want    bool
-		wantErr bool
-	}{
-		"未指定は偽":    {want: false},
-		"空文字は偽":    {value: "", want: false},
-		"1は真":      {value: "1", want: true},
-		"trueは真":   {value: "true", want: true},
-		"TRUEは真":   {value: "TRUE", want: true},
-		"yesは真":    {value: "yes", want: true},
-		"onは真":     {value: "on", want: true},
-		"0は偽":      {value: "0", want: false},
-		"falseは偽":  {value: "false", want: false},
-		"FALSEは偽":  {value: "FALSE", want: false},
-		"noは偽":     {value: "no", want: false},
-		"offは偽":    {value: "off", want: false},
-		"無効値はエラー":  {value: "maybe", wantErr: true},
-		"前後空白はトリム": {value: "  true  ", want: true},
-	}
-
-	for name, tc := range cases {
-		tc := tc
-		t.Run(name, func(t *testing.T) {
-			t.Parallel()
-
-			q := map[string][]string{}
-			if tc.value != "" || (tc.value == "" && name == "空文字は偽") {
-				q["flag"] = []string{tc.value}
-			}
-
-			got, err := parseBoolParam(q, "flag")
-			if tc.wantErr {
-				if err == nil {
-					t.Fatalf("エラーを期待しましたが nil でした")
-				}
-				return
-			}
-			if err != nil {
-				t.Fatalf("予期しないエラー: %v", err)
-			}
-			if got != tc.want {
-				t.Fatalf("結果が一致しません: got=%v want=%v", got, tc.want)
-			}
-		})
-	}
-}
-
-func TestParseIntParamは整数入力を検証する(t *testing.T) {
-	t.Parallel()
-
-	cases := map[string]struct {
-		value   string
-		want    int
-		wantErr bool
-	}{
-		"未指定は0":   {want: 0},
-		"空文字は0":   {value: "", want: 0},
-		"空白だけは0":  {value: "   ", want: 0},
-		"正の数":     {value: "120", want: 120},
-		"負の数も許容":  {value: "-1", want: -1},
-		"無効値はエラー": {value: "abc", wantErr: true},
-	}
-
-	for name, tc := range cases {
-		tc := tc
-		t.Run(name, func(t *testing.T) {
-			t.Parallel()
-
-			q := map[string][]string{}
-			if tc.value != "" || strings.Contains(name, "空文字") {
-				q["n"] = []string{tc.value}
-			}
-
-			got, err := parseIntParam(q, "n")
-			if tc.wantErr {
-				if err == nil {
-					t.Fatalf("エラーを期待しましたが nil でした")
-				}
-				return
-			}
-			if err != nil {
-				t.Fatalf("予期しないエラー: %v", err)
-			}
-			if got != tc.want {
-				t.Fatalf("結果が一致しません: got=%d want=%d", got, tc.want)
-			}
-		})
-	}
-}
-
 func TestAPIScanHandlerは不正なtruncateで400を返す(t *testing.T) {
 	t.Parallel()
 
@@ -393,6 +299,23 @@ func TestAPIScanHandlerは不正なtruncateで400を返す(t *testing.T) {
 	}
 	if body := rr.Body.String(); !strings.Contains(body, "truncate") {
 		t.Fatalf("エラーメッセージにキー名が含まれていません: %q", body)
+	}
+}
+
+func TestAPIScanHandlerは不正なboolで400を返す(t *testing.T) {
+	t.Parallel()
+
+	handler := apiScanHandler(".")
+	req := httptest.NewRequest(http.MethodGet, "/api/scan?with_comment=maybe", nil)
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("ステータスコードが一致しません: got=%d want=%d", rr.Code, http.StatusBadRequest)
+	}
+	if body := rr.Body.String(); !strings.Contains(body, "with_comment") {
+		t.Fatalf("エラーメッセージにパラメータ名が含まれていません: %q", body)
 	}
 }
 

--- a/internal/engine/opts/opts.go
+++ b/internal/engine/opts/opts.go
@@ -1,0 +1,220 @@
+package opts
+
+import (
+	"fmt"
+	"math"
+	"net/url"
+	"runtime"
+	"strconv"
+	"strings"
+
+	"github.com/example/todox/internal/engine"
+)
+
+// Defaults は CLI / Web の双方で利用する共通既定値を返します。
+func Defaults(repoDir string) engine.Options {
+	jobs := runtime.NumCPU()
+	if jobs < 1 {
+		jobs = 1
+	}
+	if jobs > 64 {
+		jobs = 64
+	}
+	return engine.Options{
+		Type:         "both",
+		Mode:         "last",
+		WithComment:  false,
+		WithMessage:  false,
+		TruncAll:     0,
+		TruncComment: 0,
+		TruncMessage: 0,
+		IgnoreWS:     true,
+		Jobs:         jobs,
+		RepoDir:      repoDir,
+		Progress:     false,
+	}
+}
+
+// ApplyWebQueryToOptions は URL クエリ文字列を Options に反映します。
+func ApplyWebQueryToOptions(def engine.Options, q url.Values) (engine.Options, error) {
+	opts := def
+
+	if raw, ok := lastValue(q, "type"); ok {
+		opts.Type = strings.ToLower(raw)
+	}
+	if raw, ok := lastValue(q, "mode"); ok {
+		opts.Mode = strings.ToLower(raw)
+	}
+	if raw, ok := lastValue(q, "author"); ok {
+		opts.AuthorRegex = raw
+	}
+	if raw, ok := lastValue(q, "repo"); ok {
+		opts.RepoDir = raw
+	}
+	if raw, ok := lastValue(q, "with_comment"); ok {
+		v, err := ParseBool(raw, "with_comment")
+		if err != nil {
+			return opts, err
+		}
+		opts.WithComment = v
+	}
+	if raw, ok := lastValue(q, "with_message"); ok {
+		v, err := ParseBool(raw, "with_message")
+		if err != nil {
+			return opts, err
+		}
+		opts.WithMessage = v
+	}
+	if raw, ok := lastValue(q, "ignore_ws"); ok {
+		v, err := ParseBool(raw, "ignore_ws")
+		if err != nil {
+			return opts, err
+		}
+		opts.IgnoreWS = v
+	}
+	if raw, ok := lastValue(q, "jobs"); ok {
+		v, err := ParseIntInRange(raw, "jobs", 1, 64)
+		if err != nil {
+			return opts, err
+		}
+		opts.Jobs = v
+	}
+	if raw, ok := lastValue(q, "truncate"); ok {
+		v, err := ParseIntInRange(raw, "truncate", 0, math.MinInt)
+		if err != nil {
+			return opts, err
+		}
+		opts.TruncAll = v
+	}
+	if raw, ok := lastValue(q, "truncate_comment"); ok {
+		v, err := ParseIntInRange(raw, "truncate_comment", 0, math.MinInt)
+		if err != nil {
+			return opts, err
+		}
+		opts.TruncComment = v
+	}
+	if raw, ok := lastValue(q, "truncate_message"); ok {
+		v, err := ParseIntInRange(raw, "truncate_message", 0, math.MinInt)
+		if err != nil {
+			return opts, err
+		}
+		opts.TruncMessage = v
+	}
+	if raw, ok := lastValue(q, "progress"); ok {
+		v, err := ParseBool(raw, "progress")
+		if err != nil {
+			return opts, err
+		}
+		opts.Progress = v
+	}
+
+	if err := NormalizeAndValidate(&opts); err != nil {
+		return opts, err
+	}
+	return opts, nil
+}
+
+// NormalizeAndValidate は Options の小文字化や範囲チェックを行います。
+func NormalizeAndValidate(o *engine.Options) error {
+	o.Type = strings.TrimSpace(strings.ToLower(o.Type))
+	switch o.Type {
+	case "", "both":
+		o.Type = "both"
+	case "todo", "fixme":
+	default:
+		return fmt.Errorf("invalid --type: %s", o.Type)
+	}
+
+	o.Mode = strings.TrimSpace(strings.ToLower(o.Mode))
+	switch o.Mode {
+	case "", "last":
+		o.Mode = "last"
+	case "first":
+	default:
+		return fmt.Errorf("invalid --mode: %s", o.Mode)
+	}
+
+	if o.TruncAll < 0 {
+		return fmt.Errorf("truncate must be >= 0")
+	}
+	if o.TruncComment < 0 {
+		return fmt.Errorf("truncate_comment must be >= 0")
+	}
+	if o.TruncMessage < 0 {
+		return fmt.Errorf("truncate_message must be >= 0")
+	}
+
+	if o.Jobs < 1 || o.Jobs > 64 {
+		return fmt.Errorf("jobs must be between 1 and 64")
+	}
+	return nil
+}
+
+// ParseBool は真偽値のバリエーションを受理して bool を返します。
+func ParseBool(raw, key string) (bool, error) {
+	v := strings.TrimSpace(strings.ToLower(raw))
+	switch v {
+	case "1", "true", "yes", "on":
+		return true, nil
+	case "0", "false", "no", "off":
+		return false, nil
+	default:
+		return false, fmt.Errorf("invalid value for %s: %q", key, raw)
+	}
+}
+
+// ParseIntInRange は整数の解析と範囲チェックを行います。
+// max < min の場合は上限無しとして扱います。
+func ParseIntInRange(raw, key string, min, max int) (int, error) {
+	n, err := strconv.Atoi(strings.TrimSpace(raw))
+	if err != nil {
+		return 0, fmt.Errorf("invalid integer value for %s: %q", key, raw)
+	}
+	if n < min {
+		if max >= min {
+			return 0, fmt.Errorf("%s must be between %d and %d", key, min, max)
+		}
+		return 0, fmt.Errorf("%s must be >= %d", key, min)
+	}
+	if max >= min && n > max {
+		return 0, fmt.Errorf("%s must be between %d and %d", key, min, max)
+	}
+	return n, nil
+}
+
+// NormalizeOutput は出力形式の小文字化と検証を行います。
+func NormalizeOutput(raw string) (string, error) {
+	out := strings.TrimSpace(strings.ToLower(raw))
+	if out == "" {
+		out = "table"
+	}
+	switch out {
+	case "table", "tsv", "json":
+		return out, nil
+	default:
+		return "", fmt.Errorf("invalid --output: %s", raw)
+	}
+}
+
+// SplitMulti は "foo,bar" のような複数指定を分割しトリムします。
+func SplitMulti(vals []string) []string {
+	var out []string
+	for _, v := range vals {
+		parts := strings.Split(v, ",")
+		for _, p := range parts {
+			p = strings.TrimSpace(p)
+			if p != "" {
+				out = append(out, p)
+			}
+		}
+	}
+	return out
+}
+
+func lastValue(q url.Values, key string) (string, bool) {
+	vals := SplitMulti(q[key])
+	if len(vals) == 0 {
+		return "", false
+	}
+	return vals[len(vals)-1], true
+}

--- a/internal/engine/opts/opts_test.go
+++ b/internal/engine/opts/opts_test.go
@@ -1,0 +1,123 @@
+package opts
+
+import (
+	"math"
+	"net/url"
+	"testing"
+
+	"github.com/example/todox/internal/engine"
+)
+
+func TestParseBoolVariants(t *testing.T) {
+	trueVals := []string{"1", "true", "TRUE", "yes", "On"}
+	falseVals := []string{"0", "false", "FALSE", "no", "OFF"}
+
+	for _, tc := range trueVals {
+		t.Run("true/"+tc, func(t *testing.T) {
+			got, err := ParseBool(tc, "flag")
+			if err != nil {
+				t.Fatalf("ParseBool(%q) error: %v", tc, err)
+			}
+			if !got {
+				t.Fatalf("ParseBool(%q) = false, want true", tc)
+			}
+		})
+	}
+
+	for _, tc := range falseVals {
+		t.Run("false/"+tc, func(t *testing.T) {
+			got, err := ParseBool(tc, "flag")
+			if err != nil {
+				t.Fatalf("ParseBool(%q) error: %v", tc, err)
+			}
+			if got {
+				t.Fatalf("ParseBool(%q) = true, want false", tc)
+			}
+		})
+	}
+
+	if _, err := ParseBool("maybe", "flag"); err == nil {
+		t.Fatal("ParseBool should reject unknown values")
+	}
+}
+
+func TestParseIntInRange(t *testing.T) {
+	got, err := ParseIntInRange("42", "jobs", 1, 64)
+	if err != nil {
+		t.Fatalf("ParseIntInRange error: %v", err)
+	}
+	if got != 42 {
+		t.Fatalf("ParseIntInRange = %d, want 42", got)
+	}
+
+	if _, err := ParseIntInRange("-1", "truncate", 0, math.MinInt); err == nil {
+		t.Fatal("ParseIntInRange should reject negative values when min=0")
+	}
+
+	if _, err := ParseIntInRange("65", "jobs", 1, 64); err == nil {
+		t.Fatal("ParseIntInRange should reject values above max")
+	}
+}
+
+func TestNormalizeAndValidate(t *testing.T) {
+	o := engine.Options{Type: "TODO", Mode: "FIRST", Jobs: 8}
+	if err := NormalizeAndValidate(&o); err != nil {
+		t.Fatalf("NormalizeAndValidate error: %v", err)
+	}
+	if o.Type != "todo" {
+		t.Fatalf("Type normalized incorrectly: %q", o.Type)
+	}
+	if o.Mode != "first" {
+		t.Fatalf("Mode normalized incorrectly: %q", o.Mode)
+	}
+
+	bad := engine.Options{Type: "maybe", Mode: "last", Jobs: 4}
+	if err := NormalizeAndValidate(&bad); err == nil {
+		t.Fatal("NormalizeAndValidate should fail for invalid type")
+	}
+
+	jobs := engine.Options{Type: "todo", Mode: "last", Jobs: 1024}
+	if err := NormalizeAndValidate(&jobs); err == nil {
+		t.Fatal("NormalizeAndValidate should fail for invalid jobs")
+	}
+}
+
+func TestApplyWebQueryToOptions(t *testing.T) {
+	def := Defaults("/repo")
+	q := url.Values{}
+	q.Set("type", "TODO")
+	q.Set("mode", "FIRST")
+	q.Set("with_comment", "yes")
+	q.Set("jobs", "4")
+
+	got, err := ApplyWebQueryToOptions(def, q)
+	if err != nil {
+		t.Fatalf("ApplyWebQueryToOptions error: %v", err)
+	}
+	if got.Type != "todo" {
+		t.Fatalf("Type mismatch: %q", got.Type)
+	}
+	if got.Mode != "first" {
+		t.Fatalf("Mode mismatch: %q", got.Mode)
+	}
+	if !got.WithComment {
+		t.Fatal("WithComment should be true")
+	}
+	if got.Jobs != 4 {
+		t.Fatalf("Jobs mismatch: %d", got.Jobs)
+	}
+}
+
+func TestSplitMulti(t *testing.T) {
+	vals := []string{"a,b", " c ", "", ",d"}
+	got := SplitMulti(vals)
+	want := []string{"a", "b", "c", "d"}
+	if len(got) != len(want) {
+		t.Fatalf("SplitMulti length mismatch: got=%d want=%d", len(got), len(want))
+	}
+	for i, v := range want {
+		if got[i] != v {
+			t.Fatalf("SplitMulti mismatch at %d: got=%q want=%q", i, got[i], v)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add a shared internal/engine/opts layer to normalize CLI and web parameters
- update the CLI parser and API handler to consume the shared normalization
- document the common input rules and extend unit coverage

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d90573f9a883209bad3433fa204b0a