### PR TITLE
Expose ignore_ws and jobs query parameters for /api/scan

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -128,6 +128,7 @@ make build
 
 - `--no-progress` / `--progress` : 進捗表示を抑止／強制
 - `--no-ignore-ws` : `git blame` で `-w` を使わない（空白変更も最新扱い）
+- Web API: `ignore_ws=0` で空白のみの変更も追跡し、`jobs=<n>` (1〜64) でワーカー数を制限できます
 
 ### ヘルプ・言語設定
 

--- a/README-ja.md
+++ b/README-ja.md
@@ -73,6 +73,8 @@ make build
 # -> http://localhost:8080 （API: /api/scan）
 ```
 
+Web フォームはサーバー既定に合わせています。`ignore whitespace` チェックは最初から ON（= `ignore_ws=true`）で、`jobs` 欄は空欄（自動）。既定のままならクエリに含めず、変更したときだけパラメータを送信します。
+
 ---
 
 ## Dev Container（推奨の開発環境）

--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ make build
 
 - `--no-progress` / `--progress`: disable or force the progress display
 - `--no-ignore-ws`: run `git blame` without `-w` so whitespace-only edits are considered latest
+- Web API: pass `ignore_ws=0` to honour whitespace edits and `jobs=<n>` (1–64) to cap worker concurrency
 
 ### Help & language
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ make build
 # -> http://localhost:8080 (JSON API: /api/scan)
 ```
 
+The web form mirrors the server defaults: *ignore whitespace* starts checked (matching `ignore_ws=true`) and the *jobs* field is blank (auto). Those parameters are only sent when you explicitly change them, so leaving the defaults keeps the API behaviour unchanged.
+
 ---
 
 ## Dev Container (recommended development setup)

--- a/cmd/todox/api_scan_params_test.go
+++ b/cmd/todox/api_scan_params_test.go
@@ -1,0 +1,186 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/phyten/todox/internal/engine"
+)
+
+func TestAPIScanHandlerはignoreWSクエリで責任コミットを切り替える(t *testing.T) {
+	t.Parallel()
+
+	repoDir := t.TempDir()
+	runGit(t, repoDir, "init")
+	runGit(t, repoDir, "config", "user.name", "Tester")
+	runGit(t, repoDir, "config", "user.email", "tester@example.com")
+
+	initialSource := "package main\n\nfunc main() {\n    // TODO: adjust spacing\n}\n"
+	if err := os.WriteFile(filepath.Join(repoDir, "main.go"), []byte(initialSource), 0o644); err != nil {
+		t.Fatalf("ファイルの作成に失敗しました: %v", err)
+	}
+	runGit(t, repoDir, "add", ".")
+	runGit(t, repoDir, "commit", "-m", "initial todo")
+
+	initialSHA := gitRevParse(t, repoDir, "HEAD")
+
+	updatedSource := "package main\n\nfunc main() {\n        // TODO: adjust spacing\n}\n"
+	if err := os.WriteFile(filepath.Join(repoDir, "main.go"), []byte(updatedSource), 0o644); err != nil {
+		t.Fatalf("ファイルの更新に失敗しました: %v", err)
+	}
+	runGit(t, repoDir, "commit", "-am", "whitespace tweak")
+
+	latestSHA := gitRevParse(t, repoDir, "HEAD")
+	if latestSHA == initialSHA {
+		t.Fatal("コミットのSHAが同じです (whitespace tweak が失敗しています)")
+	}
+
+	handler := apiScanHandler(repoDir)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/scan", nil)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("ステータスコードが一致しません: got=%d want=%d", rr.Code, http.StatusOK)
+	}
+
+	var res engine.Result
+	if err := json.NewDecoder(rr.Body).Decode(&res); err != nil {
+		t.Fatalf("レスポンスのデコードに失敗しました: %v", err)
+	}
+	if len(res.Items) != 1 {
+		t.Fatalf("TODO が1件ではありません: %+v", res.Items)
+	}
+	if res.Items[0].Commit != initialSHA {
+		t.Fatalf("ignore_ws=true のときに初回コミットが返っていません: got=%s want=%s", res.Items[0].Commit, initialSHA)
+	}
+
+	req = httptest.NewRequest(http.MethodGet, "/api/scan?ignore_ws=0", nil)
+	rr = httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("ステータスコードが一致しません: got=%d want=%d", rr.Code, http.StatusOK)
+	}
+
+	res = engine.Result{}
+	if err := json.NewDecoder(rr.Body).Decode(&res); err != nil {
+		t.Fatalf("レスポンスのデコードに失敗しました: %v", err)
+	}
+	if len(res.Items) != 1 {
+		t.Fatalf("TODO が1件ではありません: %+v", res.Items)
+	}
+	if res.Items[0].Commit != latestSHA {
+		t.Fatalf("ignore_ws=0 のときに最新コミットが返っていません: got=%s want=%s", res.Items[0].Commit, latestSHA)
+	}
+}
+
+func TestAPIScanHandlerはignoreWSの不正値で400を返す(t *testing.T) {
+	t.Parallel()
+
+	handler := apiScanHandler(".")
+	req := httptest.NewRequest(http.MethodGet, "/api/scan?ignore_ws=maybe", nil)
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("ステータスコードが一致しません: got=%d want=%d", rr.Code, http.StatusBadRequest)
+	}
+	if body := rr.Body.String(); !strings.Contains(body, "ignore_ws") {
+		t.Fatalf("エラーメッセージが期待通りではありません: %q", body)
+	}
+}
+
+func TestAPIScanHandlerはjobsパラメータを検証する(t *testing.T) {
+	t.Parallel()
+
+	handler := apiScanHandler(".")
+
+	t.Run("範囲外", func(t *testing.T) {
+		t.Parallel()
+
+		cases := []string{"0", "65"}
+		for _, raw := range cases {
+			raw := raw
+			t.Run(raw, func(t *testing.T) {
+				t.Parallel()
+
+				req := httptest.NewRequest(http.MethodGet, "/api/scan?jobs="+raw, nil)
+				rr := httptest.NewRecorder()
+				handler.ServeHTTP(rr, req)
+
+				if rr.Code != http.StatusBadRequest {
+					t.Fatalf("ステータスコードが一致しません: got=%d want=%d", rr.Code, http.StatusBadRequest)
+				}
+				if body := rr.Body.String(); !strings.Contains(body, "jobs must be between 1 and 64") {
+					t.Fatalf("エラーメッセージが期待通りではありません: %q", body)
+				}
+			})
+		}
+	})
+
+	t.Run("不正な文字列", func(t *testing.T) {
+		t.Parallel()
+
+		req := httptest.NewRequest(http.MethodGet, "/api/scan?jobs=foo", nil)
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+
+		if rr.Code != http.StatusBadRequest {
+			t.Fatalf("ステータスコードが一致しません: got=%d want=%d", rr.Code, http.StatusBadRequest)
+		}
+		if body := rr.Body.String(); !strings.Contains(body, "invalid integer value for jobs") {
+			t.Fatalf("エラーメッセージが期待通りではありません: %q", body)
+		}
+	})
+}
+
+func TestAPIScanHandlerはjobsの境界値を受け付ける(t *testing.T) {
+	t.Parallel()
+
+	repoDir := t.TempDir()
+	runGit(t, repoDir, "init")
+	runGit(t, repoDir, "config", "user.name", "Tester")
+	runGit(t, repoDir, "config", "user.email", "tester@example.com")
+	if err := os.WriteFile(filepath.Join(repoDir, "todo.txt"), []byte("// TODO boundary"), 0o644); err != nil {
+		t.Fatalf("ファイルの作成に失敗しました: %v", err)
+	}
+	runGit(t, repoDir, "add", ".")
+	runGit(t, repoDir, "commit", "-m", "initial")
+
+	handler := apiScanHandler(repoDir)
+
+	cases := []string{"1", "64"}
+	for _, raw := range cases {
+		raw := raw
+		t.Run(raw, func(t *testing.T) {
+			t.Parallel()
+
+			req := httptest.NewRequest(http.MethodGet, "/api/scan?jobs="+raw, nil)
+			rr := httptest.NewRecorder()
+			handler.ServeHTTP(rr, req)
+
+			if rr.Code != http.StatusOK {
+				t.Fatalf("ステータスコードが一致しません: got=%d want=%d", rr.Code, http.StatusOK)
+			}
+		})
+	}
+}
+
+func gitRevParse(t *testing.T, dir string, rev string) string {
+	t.Helper()
+
+	cmd := exec.Command("git", "rev-parse", rev)
+	cmd.Dir = dir
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("git rev-parse %s に失敗しました: %v", rev, err)
+	}
+	return strings.TrimSpace(string(out))
+}

--- a/cmd/todox/main.go
+++ b/cmd/todox/main.go
@@ -443,6 +443,8 @@ input[type=text]{width:240px}
 <label>author (regexp): <input name="author" type="text"></label>
 <label><input type="checkbox" name="with_comment"> comment</label>
 <label><input type="checkbox" name="with_message"> message</label>
+<label><input type="checkbox" name="ignore_ws" checked> ignore whitespace</label>
+<label>jobs: <input type="number" name="jobs" min="1" max="64" inputmode="numeric" pattern="[0-9]*" placeholder="auto"></label>
 <label>truncate: <input type="text" name="truncate" value="120"></label>
 <button>Scan</button>
 </form>
@@ -469,7 +471,30 @@ f.onsubmit=async (e)=>{
  e.preventDefault();
  hideError();
  try{
-  const q=new URLSearchParams(new FormData(f));
+  const fd=new FormData(f);
+  const q=new URLSearchParams(fd);
+
+  // ensure ignore_ws follows server default semantics (true by default)
+  {
+    const el=f.elements.namedItem('ignore_ws');
+    if(el instanceof HTMLInputElement){
+      if(el.checked){
+        q.delete('ignore_ws');
+      }else{
+        q.set('ignore_ws','0');
+      }
+    }
+  }
+
+  // only send jobs when explicitly provided
+  {
+    const el=f.elements.namedItem('jobs');
+    if(el instanceof HTMLInputElement){
+      if((el.value||'').trim()===''){
+        q.delete('jobs');
+      }
+    }
+  }
   const res=await fetch('/api/scan?'+q.toString());
   if(!res.ok){
    let msg='HTTP '+res.status;

--- a/internal/engine/opts/opts.go
+++ b/internal/engine/opts/opts.go
@@ -94,7 +94,7 @@ func ApplyWebQueryToOptions(def engine.Options, q url.Values) (engine.Options, e
 		out.TruncMessage = n
 	}
 	if raw, ok := lastLiteralValue(q["jobs"]); ok {
-		n, err := parseInt(raw, "jobs")
+		n, err := ParseIntInRange(raw, "jobs", 1, maxJobs)
 		if err != nil {
 			return out, err
 		}

--- a/internal/engine/opts/opts_test.go
+++ b/internal/engine/opts/opts_test.go
@@ -191,6 +191,11 @@ func TestApplyWebQueryToOptions(t *testing.T) {
 	if _, err := ApplyWebQueryToOptions(base, q); err == nil {
 		t.Fatal("expected error for invalid boolean")
 	}
+
+	q.Set("jobs", "0")
+	if _, err := ApplyWebQueryToOptions(base, q); err == nil {
+		t.Fatal("expected error for jobs below range")
+	}
 }
 
 func TestSplitMulti(t *testing.T) {


### PR DESCRIPTION
## Summary
- allow `/api/scan` callers to override `ignore_ws` and `jobs` using the shared option parser
- document the new query parameters in both READMEs
- add regression tests covering the new parsing behaviour, including whitespace attribution changes

## Testing
- go test ./...

Closes #5

------
https://chatgpt.com/codex/tasks/task_e_68d927b9318c8320b80e13a1a8ef558d