### PR TITLE
Add path/exclude filters to CLI and web API

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -73,7 +73,7 @@ make build
 # -> http://localhost:8080 （API: /api/scan）
 ```
 
-Web フォームはサーバー既定に合わせています。`ignore whitespace` チェックは最初から ON（= `ignore_ws=true`）で、`jobs` 欄は空欄（自動）。既定のままならクエリに含めず、変更したときだけパラメータを送信します。
+Web フォームはサーバー既定に合わせています。`ignore whitespace` チェックは最初から ON（= `ignore_ws=true`）で、`jobs` 欄は空欄（自動）。`path` / `exclude` / `path_regex` の各テキスト欄は空のままなら送信されず、`exclude typical dirs` チェックを ON にしたときだけ `exclude_typical=1` を送信します。既定のままならクエリに含めません。
 
 ---
 
@@ -99,6 +99,13 @@ make build
 - `-t, --type {todo|fixme|both}` : スキャン対象（既定: both）
 - `-m, --mode {last|first}` : 作者の定義（既定: last）
 - `-a, --author REGEX` : 作者名/メールの正規表現フィルタ（拡張正規表現）
+
+### パスフィルタ
+
+- `--path LIST` : 指定した pathspec のみを対象に検索（カンマ区切り・繰り返し可能）
+- `--exclude LIST` : 指定した pathspec/glob を除外（カンマ区切り・繰り返し可能。`:(exclude)` や `:!` は尊重）
+- `--path-regex REGEXP` : ファイルパスに Go の正規表現を適用（OR 条件でいずれかにマッチすれば残す）
+- `--exclude-typical` : 典型的な除外セットをまとめて適用（`vendor/**`, `node_modules/**`, `dist/**`, `build/**`, `target/**`, `*.min.*`）
 
 ### 出力形式
 
@@ -152,6 +159,10 @@ CLI フラグと `/api/scan` のクエリパラメータは共通の正規化レ
 | `--mode`, `mode` | `last` / `first` | 未知の値はエラーになります。 |
 | `--output` | `table` / `tsv` / `json` | 未知の値はエラーになります（CLI のみ）。 |
 | `--jobs`, `jobs` | 1〜64 の整数 | 範囲外はエラーになります。 |
+| `--path`, `path` | pathspec / glob（カンマ区切り・繰り返し可） | 前後の空白は除去。空要素は無視します。 |
+| `--exclude`, `exclude` | 同上 | `:(exclude)` や `:!` で始まる場合はそのまま尊重し、そうでなければ内部的に `:(glob,exclude)` を付与します。 |
+| `--path-regex`, `path_regex` | Go の正規表現 | すべて事前にコンパイルし、不正なパターンは即エラーになります。 |
+| `--exclude-typical`, `exclude_typical` | 真偽値（他のフラグと同じリテラル） | 組み込みの除外セットを有効化（`vendor/**`, `node_modules/**`, `dist/**`, `build/**`, `target/**`, `*.min.*`）。 |
 | `--truncate`, `--truncate-comment`, `--truncate-message`（および API 版） | 0 以上の整数 | 負の値はエラーになります。COMMENT と MESSAGE を両方表示し、トランケート指定が無い場合は既定で 120 文字が適用されます。 |
 
 `jobs` の既定値は `min(runtime.NumCPU(), 64)`（CPU コア数を 64 で上限）です。

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ make build
 # -> http://localhost:8080 (JSON API: /api/scan)
 ```
 
-The web form mirrors the server defaults: *ignore whitespace* starts checked (matching `ignore_ws=true`) and the *jobs* field is blank (auto). Those parameters are only sent when you explicitly change them, so leaving the defaults keeps the API behaviour unchanged.
+The web form mirrors the server defaults: *ignore whitespace* starts checked (matching `ignore_ws=true`) and the *jobs* field is blank (auto). The `path`, `exclude`, and `path_regex` inputs are sent only when non-empty, and the *exclude typical dirs* checkbox emits `exclude_typical=1` when checked. Leaving everything untouched keeps the API behaviour unchanged.
 
 ---
 
@@ -98,6 +98,13 @@ make build
 - `-t, --type {todo|fixme|both}`: which markers to scan (default: both)
 - `-m, --mode {last|first}`: author definition (default: last)
 - `-a, --author REGEX`: filter by author name or email (extended regex)
+
+### Path filtering
+
+- `--path LIST`: limit the `git grep` scope to the provided pathspec(s). Accepts comma-separated values and repeated flags.
+- `--exclude LIST`: exclude pathspecs/globs (comma-separated and repeatable). `:(exclude)` / `:!` prefixes are respected.
+- `--path-regex REGEXP`: keep only matches whose file path satisfies any of the given Go regular expressions.
+- `--exclude-typical`: enable the built-in exclude set (`vendor/**`, `node_modules/**`, `dist/**`, `build/**`, `target/**`, `*.min.*`).
 
 ### Output selection
 
@@ -151,6 +158,10 @@ Both the CLI flags and the `/api/scan` query parameters share the same normaliza
 | `--mode`, `mode` | `last`, `first` | Unknown values are rejected. |
 | `--output` | `table`, `tsv`, `json` | Unknown values are rejected (CLI only). |
 | `--jobs`, `jobs` | Integers in `[1, 64]` | Values outside the range are rejected. |
+| `--path`, `path` | Pathspecs/globs, comma-separated or repeated | Values are trimmed. Empty entries are ignored. |
+| `--exclude`, `exclude` | Same as above | `:(exclude)` / `:!` prefixes are preserved; otherwise `:(glob,exclude)` is added internally. |
+| `--path-regex`, `path_regex` | Go regular expressions | Each entry must compile. Invalid patterns return an error. |
+| `--exclude-typical`, `exclude_typical` | Boolean (same literals as other flags) | Enables the built-in set: `vendor/**`, `node_modules/**`, `dist/**`, `build/**`, `target/**`, `*.min.*`. |
 | `--truncate`, `--truncate-comment`, `--truncate-message` (and the API equivalents) | Integers ≥ 0 | Negative values are rejected. When both COMMENT and MESSAGE columns are enabled and no truncate is supplied, a default of 120 runes is applied. |
 
 Default for `jobs`: `min(runtime.NumCPU(), 64)` (number of CPU cores capped at 64).

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -232,7 +232,7 @@ func TestGitGrepHandlesLongLines(t *testing.T) {
 	runGit(t, repoDir, "add", "long.go")
 	runGit(t, repoDir, "commit", "-m", "add long line")
 
-        matches, err := gitGrep(repoDir, "TODO", Options{RepoDir: repoDir})
+	matches, err := gitGrep(repoDir, "TODO", nil, nil, false)
 	if err != nil {
 		t.Fatalf("gitGrep returned error: %v", err)
 	}

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -232,7 +232,7 @@ func TestGitGrepHandlesLongLines(t *testing.T) {
 	runGit(t, repoDir, "add", "long.go")
 	runGit(t, repoDir, "commit", "-m", "add long line")
 
-	matches, err := gitGrep(repoDir, "TODO")
+        matches, err := gitGrep(repoDir, "TODO", Options{RepoDir: repoDir})
 	if err != nil {
 		t.Fatalf("gitGrep returned error: %v", err)
 	}

--- a/internal/engine/gitargs.go
+++ b/internal/engine/gitargs.go
@@ -56,7 +56,7 @@ func buildGrepPathspecs(includes, excludes []string, typical bool) []string {
 	return out
 }
 
-func compilePathRegex(patterns []string) ([]*regexp.Regexp, error) {
+func CompilePathRegex(patterns []string) ([]*regexp.Regexp, error) {
 	if len(patterns) == 0 {
 		return nil, nil
 	}
@@ -81,8 +81,9 @@ func filterByPathRegex(matches []match, rx []*regexp.Regexp) []match {
 	}
 	out := matches[:0]
 	for _, m := range matches {
+		file := strings.ReplaceAll(filepath.ToSlash(m.file), "\\", "/")
 		for _, r := range rx {
-			if r.MatchString(m.file) {
+			if r.MatchString(file) {
 				out = append(out, m)
 				break
 			}

--- a/internal/engine/gitargs.go
+++ b/internal/engine/gitargs.go
@@ -1,0 +1,92 @@
+package engine
+
+import (
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+var typicalExcludePatterns = []string{
+	":(glob,exclude)vendor/**",
+	":(glob,exclude)node_modules/**",
+	":(glob,exclude)dist/**",
+	":(glob,exclude)build/**",
+	":(glob,exclude)target/**",
+	":(glob,exclude)*.min.*",
+}
+
+// buildGrepPathspecs builds the list to append after "--" for `git grep`.
+func buildGrepPathspecs(includes, excludes []string, typical bool) []string {
+	normalizedIncludes := make([]string, 0, len(includes))
+	for _, raw := range includes {
+		trimmed := strings.TrimSpace(raw)
+		if trimmed == "" {
+			continue
+		}
+		if strings.HasPrefix(trimmed, ":") {
+			normalizedIncludes = append(normalizedIncludes, filepath.ToSlash(trimmed))
+			continue
+		}
+		normalizedIncludes = append(normalizedIncludes, filepath.ToSlash(trimmed))
+	}
+
+	out := make([]string, 0, len(normalizedIncludes)+len(excludes)+len(typicalExcludePatterns)+1)
+	if len(normalizedIncludes) == 0 {
+		out = append(out, ".")
+	} else {
+		out = append(out, normalizedIncludes...)
+	}
+
+	if typical {
+		out = append(out, typicalExcludePatterns...)
+	}
+
+	for _, raw := range excludes {
+		trimmed := strings.TrimSpace(raw)
+		if trimmed == "" {
+			continue
+		}
+		trimmed = filepath.ToSlash(trimmed)
+		if strings.HasPrefix(trimmed, ":!") || strings.HasPrefix(trimmed, ":(exclude)") || strings.HasPrefix(trimmed, ":(glob,exclude)") {
+			out = append(out, trimmed)
+			continue
+		}
+		out = append(out, ":(glob,exclude)"+trimmed)
+	}
+	return out
+}
+
+func compilePathRegex(patterns []string) ([]*regexp.Regexp, error) {
+	if len(patterns) == 0 {
+		return nil, nil
+	}
+	compiled := make([]*regexp.Regexp, 0, len(patterns))
+	for _, raw := range patterns {
+		trimmed := strings.TrimSpace(raw)
+		if trimmed == "" {
+			continue
+		}
+		rx, err := regexp.Compile(trimmed)
+		if err != nil {
+			return nil, err
+		}
+		compiled = append(compiled, rx)
+	}
+	return compiled, nil
+}
+
+func filterByPathRegex(matches []match, rx []*regexp.Regexp) []match {
+	if len(rx) == 0 {
+		return matches
+	}
+	out := matches[:0]
+	for _, m := range matches {
+		for _, r := range rx {
+			if r.MatchString(m.file) {
+				out = append(out, m)
+				break
+			}
+		}
+	}
+	return out
+}

--- a/internal/engine/gitargs_test.go
+++ b/internal/engine/gitargs_test.go
@@ -58,7 +58,7 @@ func TestBuildGrepPathspecsIncludesAndExcludes(t *testing.T) {
 func TestCompilePathRegexTrimsAndValidates(t *testing.T) {
 	t.Parallel()
 
-	rx, err := compilePathRegex([]string{"  ", "^src/", "(cmd|pkg)"})
+	rx, err := CompilePathRegex([]string{"  ", "^src/", "(cmd|pkg)"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -66,7 +66,7 @@ func TestCompilePathRegexTrimsAndValidates(t *testing.T) {
 		t.Fatalf("expected 2 regexps, got %d", len(rx))
 	}
 
-	if _, err := compilePathRegex([]string{"["}); err == nil {
+	if _, err := CompilePathRegex([]string{"["}); err == nil {
 		t.Fatal("expected compile error for invalid regexp")
 	}
 }
@@ -91,5 +91,20 @@ func TestFilterByPathRegex(t *testing.T) {
 	empty := filterByPathRegex(matches, nil)
 	if len(empty) != len(matches) {
 		t.Fatalf("expected original slice when no regex: %d vs %d", len(empty), len(matches))
+	}
+}
+
+func TestFilterByPathRegexNormalizesWindowsSeparators(t *testing.T) {
+	t.Parallel()
+
+	matches := []match{{file: `pkg\utils\todo.go`}}
+	rx := []*regexp.Regexp{regexp.MustCompile(`^pkg/utils/`)}
+
+	got := filterByPathRegex(matches, rx)
+	if len(got) != 1 {
+		t.Fatalf("expected match to survive normalization, got %d", len(got))
+	}
+	if got[0].file != matches[0].file {
+		t.Fatalf("expected original match to be retained, got %q", got[0].file)
 	}
 }

--- a/internal/engine/gitargs_test.go
+++ b/internal/engine/gitargs_test.go
@@ -1,0 +1,95 @@
+package engine
+
+import (
+	"path/filepath"
+	"regexp"
+	"testing"
+)
+
+func TestBuildGrepPathspecs_DefaultsToDot(t *testing.T) {
+	t.Parallel()
+
+	got := buildGrepPathspecs(nil, nil, false)
+	want := []string{"."}
+	if len(got) != len(want) || got[0] != want[0] {
+		t.Fatalf("unexpected result: %#v", got)
+	}
+}
+
+func TestBuildGrepPathspecsIncludesAndExcludes(t *testing.T) {
+	t.Parallel()
+
+	includes := []string{"src", " pkg ", "windows\\path"}
+	excludes := []string{"vendor/**", ":(exclude)third_party/**", ":!build/**"}
+
+	got := buildGrepPathspecs(includes, excludes, true)
+
+	expectedHead := []string{"src", "pkg", filepath.ToSlash("windows\\path")}
+	for i, want := range expectedHead {
+		if i >= len(got) || got[i] != filepath.ToSlash(want) {
+			t.Fatalf("include %d mismatch: got=%v want=%v", i, got, expectedHead)
+		}
+	}
+
+	// typical excludes should follow includes
+	typical := typicalExcludePatterns
+	start := len(expectedHead)
+	if len(got) < start+len(typical) {
+		t.Fatalf("expected typical excludes to be appended: %v", got)
+	}
+	for i, want := range typical {
+		if got[start+i] != want {
+			t.Fatalf("typical exclude mismatch at %d: got=%q want=%q", start+i, got[start+i], want)
+		}
+	}
+
+	tail := got[start+len(typical):]
+	expectedTail := []string{":(glob,exclude)vendor/**", ":(exclude)third_party/**", ":!build/**"}
+	if len(tail) != len(expectedTail) {
+		t.Fatalf("exclude length mismatch: got=%v want=%v", tail, expectedTail)
+	}
+	for i, want := range expectedTail {
+		if tail[i] != want {
+			t.Fatalf("exclude %d mismatch: got=%q want=%q", i, tail[i], want)
+		}
+	}
+}
+
+func TestCompilePathRegexTrimsAndValidates(t *testing.T) {
+	t.Parallel()
+
+	rx, err := compilePathRegex([]string{"  ", "^src/", "(cmd|pkg)"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(rx) != 2 {
+		t.Fatalf("expected 2 regexps, got %d", len(rx))
+	}
+
+	if _, err := compilePathRegex([]string{"["}); err == nil {
+		t.Fatal("expected compile error for invalid regexp")
+	}
+}
+
+func TestFilterByPathRegex(t *testing.T) {
+	t.Parallel()
+
+	matches := []match{{file: "src/main.go"}, {file: "pkg/util.go"}, {file: "docs/readme.md"}}
+	rx := []*regexp.Regexp{regexp.MustCompile(`^src/`), regexp.MustCompile(`\.go$`)}
+
+	got := filterByPathRegex(matches, rx)
+	want := []match{{file: "src/main.go"}, {file: "pkg/util.go"}}
+	if len(got) != len(want) {
+		t.Fatalf("expected %d matches, got %d", len(want), len(got))
+	}
+	for i := range want {
+		if got[i].file != want[i].file {
+			t.Fatalf("match %d mismatch: got=%q want=%q", i, got[i].file, want[i].file)
+		}
+	}
+
+	empty := filterByPathRegex(matches, nil)
+	if len(empty) != len(matches) {
+		t.Fatalf("expected original slice when no regex: %d vs %d", len(empty), len(matches))
+	}
+}

--- a/internal/engine/opts/opts.go
+++ b/internal/engine/opts/opts.go
@@ -3,7 +3,6 @@ package opts
 import (
 	"fmt"
 	"net/url"
-	"regexp"
 	"runtime"
 	"strconv"
 	"strings"
@@ -184,11 +183,11 @@ func NormalizeAndValidate(o *engine.Options) error {
 	o.Excludes = trimSlice(o.Excludes)
 	o.PathRegex = trimSlice(o.PathRegex)
 
-	for _, pattern := range o.PathRegex {
-		if _, err := regexp.Compile(pattern); err != nil {
-			return fmt.Errorf("invalid --path-regex: %w", err)
-		}
+	compiled, err := engine.CompilePathRegex(o.PathRegex)
+	if err != nil {
+		return fmt.Errorf("invalid --path-regex: %w", err)
 	}
+	o.PathRegexCompiled = compiled
 
 	return nil
 }

--- a/internal/engine/opts/opts.go
+++ b/internal/engine/opts/opts.go
@@ -3,6 +3,7 @@ package opts
 import (
 	"fmt"
 	"net/url"
+	"regexp"
 	"runtime"
 	"strconv"
 	"strings"
@@ -114,6 +115,22 @@ func ApplyWebQueryToOptions(def engine.Options, q url.Values) (engine.Options, e
 		}
 		out.Progress = v
 	}
+	if raw := q["path"]; len(raw) > 0 {
+		out.Paths = SplitMulti(raw)
+	}
+	if raw := q["exclude"]; len(raw) > 0 {
+		out.Excludes = SplitMulti(raw)
+	}
+	if raw := q["path_regex"]; len(raw) > 0 {
+		out.PathRegex = SplitMulti(raw)
+	}
+	if raw, ok := lastLiteralValue(q["exclude_typical"]); ok {
+		v, err := ParseBool(raw, "exclude_typical")
+		if err != nil {
+			return out, err
+		}
+		out.ExcludeTypical = v
+	}
 	if raw, ok := lastRawValue(q["repo"]); ok {
 		out.RepoDir = raw
 	}
@@ -161,6 +178,16 @@ func NormalizeAndValidate(o *engine.Options) error {
 
 	if strings.TrimSpace(o.RepoDir) == "" {
 		o.RepoDir = "."
+	}
+
+	o.Paths = trimSlice(o.Paths)
+	o.Excludes = trimSlice(o.Excludes)
+	o.PathRegex = trimSlice(o.PathRegex)
+
+	for _, pattern := range o.PathRegex {
+		if _, err := regexp.Compile(pattern); err != nil {
+			return fmt.Errorf("invalid --path-regex: %w", err)
+		}
 	}
 
 	return nil
@@ -251,4 +278,19 @@ func lastRawValue(vals []string) (string, bool) {
 		return trimmed, true
 	}
 	return "", false
+}
+
+func trimSlice(values []string) []string {
+	if len(values) == 0 {
+		return values
+	}
+	out := values[:0]
+	for _, v := range values {
+		trimmed := strings.TrimSpace(v)
+		if trimmed == "" {
+			continue
+		}
+		out = append(out, trimmed)
+	}
+	return out
 }

--- a/internal/engine/opts/opts_test.go
+++ b/internal/engine/opts/opts_test.go
@@ -121,6 +121,9 @@ func TestNormalizeAndValidate(t *testing.T) {
 	if len(opts.PathRegex) != 1 || opts.PathRegex[0] != "^src/" {
 		t.Fatalf("path regex should be trimmed: %#v", opts.PathRegex)
 	}
+	if len(opts.PathRegexCompiled) != 1 || opts.PathRegexCompiled[0].String() != "^src/" {
+		t.Fatalf("compiled regex should mirror trimmed pattern: %#v", opts.PathRegexCompiled)
+	}
 
 	bad := engine.Options{Type: "unknown", Mode: "last", Jobs: 1}
 	if err := NormalizeAndValidate(&bad); err == nil {

--- a/internal/engine/opts/opts_test.go
+++ b/internal/engine/opts/opts_test.go
@@ -2,6 +2,7 @@ package opts
 
 import (
 	"net/url"
+	"reflect"
 	"testing"
 
 	"github.com/phyten/todox/internal/engine"
@@ -91,6 +92,9 @@ func TestNormalizeAndValidate(t *testing.T) {
 		IgnoreWS:     true,
 		Jobs:         8,
 		RepoDir:      "",
+		Paths:        []string{" src ", ""},
+		Excludes:     []string{" vendor/** ", ""},
+		PathRegex:    []string{"^src/", ""},
 	}
 
 	if err := NormalizeAndValidate(&opts); err != nil {
@@ -108,6 +112,15 @@ func TestNormalizeAndValidate(t *testing.T) {
 	if opts.RepoDir != "." {
 		t.Fatalf("repo dir should default to '.' when empty: %q", opts.RepoDir)
 	}
+	if len(opts.Paths) != 1 || opts.Paths[0] != "src" {
+		t.Fatalf("paths should be trimmed: %#v", opts.Paths)
+	}
+	if len(opts.Excludes) != 1 || opts.Excludes[0] != "vendor/**" {
+		t.Fatalf("excludes should be trimmed: %#v", opts.Excludes)
+	}
+	if len(opts.PathRegex) != 1 || opts.PathRegex[0] != "^src/" {
+		t.Fatalf("path regex should be trimmed: %#v", opts.PathRegex)
+	}
 
 	bad := engine.Options{Type: "unknown", Mode: "last", Jobs: 1}
 	if err := NormalizeAndValidate(&bad); err == nil {
@@ -122,6 +135,11 @@ func TestNormalizeAndValidate(t *testing.T) {
 	trunc := engine.Options{Type: "todo", Mode: "last", Jobs: 8, TruncComment: -1}
 	if err := NormalizeAndValidate(&trunc); err == nil {
 		t.Fatal("expected error for negative truncate")
+	}
+
+	invalidRegex := engine.Options{Type: "todo", Mode: "last", Jobs: 1, PathRegex: []string{"["}}
+	if err := NormalizeAndValidate(&invalidRegex); err == nil {
+		t.Fatal("expected error for invalid path regex")
 	}
 }
 
@@ -151,6 +169,14 @@ func TestApplyWebQueryToOptions(t *testing.T) {
 	q.Add("progress", "1")
 	q.Add("author", "Alice")
 	q.Add("author", " Bob ")
+	q.Add("path", "src,pkg")
+	q.Add("path", "cmd")
+	q.Add("exclude", "vendor/**,dist/**")
+	q.Add("exclude", " node_modules/** ")
+	q.Add("path_regex", "^src/")
+	q.Add("path_regex", "\\.go$")
+	q.Add("exclude_typical", "0")
+	q.Add("exclude_typical", "1")
 
 	got, err := ApplyWebQueryToOptions(base, q)
 	if err != nil {
@@ -185,6 +211,18 @@ func TestApplyWebQueryToOptions(t *testing.T) {
 	}
 	if got.AuthorRegex != "Bob" {
 		t.Fatalf("expected author to use last raw value, got %q", got.AuthorRegex)
+	}
+	if want := []string{"src", "pkg", "cmd"}; !reflect.DeepEqual(got.Paths, want) {
+		t.Fatalf("paths mismatch: got=%v want=%v", got.Paths, want)
+	}
+	if want := []string{"vendor/**", "dist/**", "node_modules/**"}; !reflect.DeepEqual(got.Excludes, want) {
+		t.Fatalf("excludes mismatch: got=%v want=%v", got.Excludes, want)
+	}
+	if want := []string{"^src/", "\\.go$"}; !reflect.DeepEqual(got.PathRegex, want) {
+		t.Fatalf("path regex mismatch: got=%v want=%v", got.PathRegex, want)
+	}
+	if !got.ExcludeTypical {
+		t.Fatal("exclude_typical should be true when last literal is truthy")
 	}
 
 	q.Set("with_comment", "maybe")

--- a/internal/engine/types.go
+++ b/internal/engine/types.go
@@ -26,19 +26,23 @@ type ItemError struct {
 
 // Options は実行オプション
 type Options struct {
-	Type         string // todo|fixme|both
-	Mode         string // last|first
-	AuthorRegex  string
-	WithComment  bool
-	WithMessage  bool
-	TruncAll     int
-	TruncComment int
-	TruncMessage int
-	IgnoreWS     bool
-	Jobs         int
-	RepoDir      string
-	Progress     bool
-	Now          time.Time
+	Type           string // todo|fixme|both
+	Mode           string // last|first
+	AuthorRegex    string
+	WithComment    bool
+	WithMessage    bool
+	TruncAll       int
+	TruncComment   int
+	TruncMessage   int
+	IgnoreWS       bool
+	Jobs           int
+	RepoDir        string
+	Progress       bool
+	Now            time.Time
+	Paths          []string
+	Excludes       []string
+	PathRegex      []string
+	ExcludeTypical bool
 }
 
 // Result は出力

--- a/internal/engine/types.go
+++ b/internal/engine/types.go
@@ -1,6 +1,9 @@
 package engine
 
-import "time"
+import (
+	"regexp"
+	"time"
+)
 
 // Item は 1 件の TODO/FIXME を表す
 type Item struct {
@@ -26,23 +29,24 @@ type ItemError struct {
 
 // Options は実行オプション
 type Options struct {
-	Type           string // todo|fixme|both
-	Mode           string // last|first
-	AuthorRegex    string
-	WithComment    bool
-	WithMessage    bool
-	TruncAll       int
-	TruncComment   int
-	TruncMessage   int
-	IgnoreWS       bool
-	Jobs           int
-	RepoDir        string
-	Progress       bool
-	Now            time.Time
-	Paths          []string
-	Excludes       []string
-	PathRegex      []string
-	ExcludeTypical bool
+	Type              string // todo|fixme|both
+	Mode              string // last|first
+	AuthorRegex       string
+	WithComment       bool
+	WithMessage       bool
+	TruncAll          int
+	TruncComment      int
+	TruncMessage      int
+	IgnoreWS          bool
+	Jobs              int
+	RepoDir           string
+	Progress          bool
+	Now               time.Time
+	Paths             []string
+	Excludes          []string
+	PathRegex         []string
+	PathRegexCompiled []*regexp.Regexp
+	ExcludeTypical    bool
 }
 
 // Result は出力


### PR DESCRIPTION
Fixes #11 

## Summary
- add path, exclude, path_regex, and exclude_typical inputs to the CLI, web API, and shared options layer
- refactor git grep argument construction and introduce path-regex post-filtering with unit coverage
- update the web form, docs, and integration tests to reflect the new filtering features

## Testing
- go test ./...
- make lint

------
https://chatgpt.com/codex/tasks/task_e_68d93484136c8320a05e041d3f83bb63