### PR TITLE
Handle Go raw string spans and document web flag precedence

### DIFF
--- a/cmd/todox/fields.go
+++ b/cmd/todox/fields.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/phyten/todox/internal/engine"
+	"github.com/phyten/todox/internal/model"
 )
 
 type Field struct {
@@ -37,16 +38,21 @@ type fieldMeta struct {
 
 var fieldRegistry = map[string]fieldMeta{
 	"type":       {header: "TYPE"},
+	"lang":       {header: "LANG"},
+	"kind":       {header: "KIND"},
+	"tag":        {header: "TAG"},
 	"author":     {header: "AUTHOR"},
 	"email":      {header: "EMAIL"},
 	"date":       {header: "DATE"},
 	"age":        {header: "AGE", isAge: true},
 	"commit":     {header: "COMMIT"},
 	"location":   {header: "LOCATION"},
+	"text":       {header: "TEXT"},
+	"span":       {header: "SPAN"},
 	"comment":    {header: "COMMENT", isComment: true},
 	"message":    {header: "MESSAGE", isMessage: true},
 	"url":        {header: "URL", isURL: true},
-	"commit_url": {header: "URL", isURL: true},
+	"commit_url": {header: "COMMIT_URL", isURL: true},
 	"pr":         {header: "PR", isPR: true},
 	"prs":        {header: "PRS", isPR: true},
 	"pr_urls":    {header: "PR_URLS", isPR: true},
@@ -130,6 +136,12 @@ func formatFieldValue(it engine.Item, key string) string {
 	switch key {
 	case "type":
 		return it.Kind
+	case "lang":
+		return it.Lang
+	case "kind":
+		return it.MatchKind
+	case "tag":
+		return it.Tag
 	case "author":
 		return it.Author
 	case "email":
@@ -142,6 +154,10 @@ func formatFieldValue(it engine.Item, key string) string {
 		return short(it.Commit)
 	case "location":
 		return fmt.Sprintf("%s:%d", it.File, it.Line)
+	case "text":
+		return it.Text
+	case "span":
+		return formatSpan(it.Span)
 	case "comment":
 		return it.Comment
 	case "message":
@@ -198,4 +214,23 @@ func formatPRURLs(prs []engine.PullRequestRef) string {
 		parts = append(parts, pr.URL)
 	}
 	return strings.Join(parts, "; ")
+}
+
+func formatSpan(span model.Span) string {
+	if span.StartLine <= 0 {
+		return ""
+	}
+	startCol := span.StartCol
+	if startCol <= 0 {
+		startCol = 1
+	}
+	endLine := span.EndLine
+	if endLine <= 0 {
+		endLine = span.StartLine
+	}
+	endCol := span.EndCol
+	if endCol <= 0 {
+		endCol = startCol
+	}
+	return fmt.Sprintf("%d:%d-%d:%d", span.StartLine, startCol, endLine, endCol)
 }

--- a/cmd/todox/fields_test.go
+++ b/cmd/todox/fields_test.go
@@ -104,6 +104,9 @@ func TestResolveFieldsCommitURLAlias(t *testing.T) {
 	if len(sel.Fields) != 1 || sel.Fields[0].Key != "commit_url" {
 		t.Fatalf("unexpected fields for commit_url alias: %+v", sel.Fields)
 	}
+	if sel.Fields[0].Header != "COMMIT_URL" {
+		t.Fatalf("unexpected header for commit_url alias: %s", sel.Fields[0].Header)
+	}
 	if !sel.ShowURL || !sel.NeedURL {
 		t.Fatalf("URL flags should be enabled for commit_url alias: %+v", sel)
 	}

--- a/cmd/todox/flags_test.go
+++ b/cmd/todox/flags_test.go
@@ -191,6 +191,42 @@ func TestHelpOutputJapanese(t *testing.T) {
 	}
 }
 
+func TestParseScanArgsIncludeStringsLastWins(t *testing.T) {
+	cfg, err := parseScanArgs([]string{"--include-strings", "--comments-only"}, "en")
+	if err != nil {
+		t.Fatalf("parseScanArgs failed: %v", err)
+	}
+	if cfg.opts.IncludeStrings {
+		t.Fatalf("expected IncludeStrings=false when --comments-only is last, got true")
+	}
+
+	cfg, err = parseScanArgs([]string{"--comments-only", "--include-strings"}, "en")
+	if err != nil {
+		t.Fatalf("parseScanArgs failed: %v", err)
+	}
+	if !cfg.opts.IncludeStrings {
+		t.Fatalf("expected IncludeStrings=true when --include-strings is last, got false")
+	}
+}
+
+func TestParseScanArgsIncludeStringsEqualsForm(t *testing.T) {
+	cfg, err := parseScanArgs([]string{"--include-strings=false", "--comments-only=false"}, "en")
+	if err != nil {
+		t.Fatalf("parseScanArgs failed: %v", err)
+	}
+	if !cfg.opts.IncludeStrings {
+		t.Fatalf("expected IncludeStrings=true when --comments-only=false is last, got false")
+	}
+
+	cfg, err = parseScanArgs([]string{"--no-strings=false", "--comments-only"}, "en")
+	if err != nil {
+		t.Fatalf("parseScanArgs failed: %v", err)
+	}
+	if cfg.opts.IncludeStrings {
+		t.Fatalf("expected IncludeStrings=false when --comments-only is last, got true")
+	}
+}
+
 func equalSlices(a, b []string) bool {
 	if len(a) != len(b) {
 		return false

--- a/internal/config/env.go
+++ b/internal/config/env.go
@@ -67,23 +67,39 @@ func FromEnv(getenv func(string) string) (Config, error) {
 
 	setString(&cfg.Engine.Type, "TODOX_TYPE")
 	setString(&cfg.Engine.Mode, "TODOX_MODE")
+	setString(&cfg.Engine.Detect, "TODOX_DETECT")
 	setString(&cfg.Engine.Author, "TODOX_AUTHOR")
 	setList(&cfg.Engine.Paths, "TODOX_PATH")
 	setList(&cfg.Engine.Excludes, "TODOX_EXCLUDE")
 	setList(&cfg.Engine.PathRegex, "TODOX_PATH_REGEX")
+	setList(&cfg.Engine.DetectLangs, "TODOX_DETECT_LANGS")
+	setList(&cfg.Engine.Tags, "TODOX_TAGS")
 	setBool(&cfg.Engine.ExcludeTypical, "TODOX_EXCLUDE_TYPICAL")
 	setString(&cfg.Engine.Output, "TODOX_OUTPUT")
 	setString(&cfg.Engine.Color, "TODOX_COLOR")
 	setBool(&cfg.Engine.WithComment, "TODOX_WITH_COMMENT")
 	setBool(&cfg.Engine.WithMessage, "TODOX_WITH_MESSAGE")
+	setBool(&cfg.Engine.IncludeStrings, "TODOX_INCLUDE_STRINGS")
+	setBool(&cfg.Engine.CommentsOnly, "TODOX_COMMENTS_ONLY")
+	if raw := strings.TrimSpace(getenv("TODOX_NO_STRINGS")); raw != "" {
+		v, err := engineopts.ParseBool(raw, "TODOX_NO_STRINGS")
+		if err != nil {
+			errs = append(errs, err)
+		} else {
+			value := !v
+			cfg.Engine.IncludeStrings = &value
+		}
+	}
 	setInt(&cfg.Engine.TruncAll, "TODOX_TRUNCATE", 0, math.MaxInt)
 	setInt(&cfg.Engine.TruncComment, "TODOX_TRUNCATE_COMMENT", 0, math.MaxInt)
 	setInt(&cfg.Engine.TruncMessage, "TODOX_TRUNCATE_MESSAGE", 0, math.MaxInt)
 	setBool(&cfg.Engine.IgnoreWS, "TODOX_IGNORE_WS")
+	setInt(&cfg.Engine.MaxFileBytes, "TODOX_MAX_FILE_BYTES", 0, math.MaxInt)
 	// Allow large values here and rely on NormalizeAndValidate to enforce the
 	// canonical upper bound so every input path shares the same error message.
 	setInt(&cfg.Engine.Jobs, "TODOX_JOBS", 0, math.MaxInt)
 	setString(&cfg.Engine.Repo, "TODOX_REPO")
+	setBool(&cfg.Engine.NoPrefilter, "TODOX_NO_PREFILTER")
 
 	setBool(&cfg.UI.WithCommitLink, "TODOX_WITH_COMMIT_LINK")
 	setBool(&cfg.UI.WithPRLinks, "TODOX_WITH_PR_LINKS")

--- a/internal/config/merge.go
+++ b/internal/config/merge.go
@@ -2,11 +2,17 @@ package config
 
 import "strings"
 
+func boolPtr(v bool) *bool {
+	b := v
+	return &b
+}
+
 func MergeEngine(base EngineSettings, layers ...EngineConfig) EngineSettings {
 	out := base
 	for _, layer := range layers {
 		out.Type = ResolveString(out.Type, layer.Type)
 		out.Mode = ResolveString(out.Mode, layer.Mode)
+		out.Detect = ResolveString(out.Detect, layer.Detect)
 		out.Author = ResolveString(out.Author, layer.Author)
 		out.Paths = ResolveStrings(out.Paths, layer.Paths)
 		out.Excludes = ResolveStrings(out.Excludes, layer.Excludes)
@@ -14,6 +20,12 @@ func MergeEngine(base EngineSettings, layers ...EngineConfig) EngineSettings {
 		out.ExcludeTypical = ResolveBool(out.ExcludeTypical, layer.ExcludeTypical)
 		out.WithComment = ResolveBool(out.WithComment, layer.WithComment)
 		out.WithMessage = ResolveBool(out.WithMessage, layer.WithMessage)
+		out.IncludeStrings = ResolveBool(out.IncludeStrings, layer.IncludeStrings)
+		if layer.CommentsOnly != nil {
+			out.IncludeStrings = ResolveBool(out.IncludeStrings, boolPtr(!*layer.CommentsOnly))
+		}
+		out.DetectLangs = ResolveStrings(out.DetectLangs, layer.DetectLangs)
+		out.Tags = ResolveStrings(out.Tags, layer.Tags)
 		out.TruncAll = ResolveInt(out.TruncAll, layer.TruncAll)
 		out.TruncComment = ResolveInt(out.TruncComment, layer.TruncComment)
 		out.TruncMessage = ResolveInt(out.TruncMessage, layer.TruncMessage)
@@ -22,6 +34,8 @@ func MergeEngine(base EngineSettings, layers ...EngineConfig) EngineSettings {
 		out.Repo = ResolveAndTrim(out.Repo, layer.Repo)
 		out.Output = ResolveAndTrim(out.Output, layer.Output)
 		out.Color = ResolveAndTrim(out.Color, layer.Color)
+		out.MaxFileBytes = ResolveInt(out.MaxFileBytes, layer.MaxFileBytes)
+		out.NoPrefilter = ResolveBool(out.NoPrefilter, layer.NoPrefilter)
 	}
 	if strings.TrimSpace(out.Output) == "" {
 		out.Output = "table"

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -9,6 +9,7 @@ import (
 type EngineConfig struct {
 	Type           *string   `yaml:"type" toml:"type" json:"type"`
 	Mode           *string   `yaml:"mode" toml:"mode" json:"mode"`
+	Detect         *string   `yaml:"detect" toml:"detect" json:"detect"`
 	Author         *string   `yaml:"author" toml:"author" json:"author"`
 	Paths          *[]string `yaml:"path" toml:"path" json:"path"`
 	Excludes       *[]string `yaml:"exclude" toml:"exclude" json:"exclude"`
@@ -16,6 +17,10 @@ type EngineConfig struct {
 	ExcludeTypical *bool     `yaml:"exclude_typical" toml:"exclude_typical" json:"exclude_typical"`
 	WithComment    *bool     `yaml:"with_comment" toml:"with_comment" json:"with_comment"`
 	WithMessage    *bool     `yaml:"with_message" toml:"with_message" json:"with_message"`
+	IncludeStrings *bool     `yaml:"include_strings" toml:"include_strings" json:"include_strings"`
+	CommentsOnly   *bool     `yaml:"comments_only" toml:"comments_only" json:"comments_only"`
+	DetectLangs    *[]string `yaml:"detect_langs" toml:"detect_langs" json:"detect_langs"`
+	Tags           *[]string `yaml:"tags" toml:"tags" json:"tags"`
 	TruncAll       *int      `yaml:"truncate" toml:"truncate" json:"truncate"`
 	TruncComment   *int      `yaml:"truncate_comment" toml:"truncate_comment" json:"truncate_comment"`
 	TruncMessage   *int      `yaml:"truncate_message" toml:"truncate_message" json:"truncate_message"`
@@ -24,6 +29,8 @@ type EngineConfig struct {
 	Repo           *string   `yaml:"repo" toml:"repo" json:"repo"`
 	Output         *string   `yaml:"output" toml:"output" json:"output"`
 	Color          *string   `yaml:"color" toml:"color" json:"color"`
+	MaxFileBytes   *int      `yaml:"max_file_bytes" toml:"max_file_bytes" json:"max_file_bytes"`
+	NoPrefilter    *bool     `yaml:"no_prefilter" toml:"no_prefilter" json:"no_prefilter"`
 }
 
 type UIConfig struct {
@@ -45,6 +52,7 @@ type Config struct {
 type EngineSettings struct {
 	Type           string
 	Mode           string
+	Detect         string
 	Author         string
 	Paths          []string
 	Excludes       []string
@@ -52,6 +60,9 @@ type EngineSettings struct {
 	ExcludeTypical bool
 	WithComment    bool
 	WithMessage    bool
+	IncludeStrings bool
+	DetectLangs    []string
+	Tags           []string
 	TruncAll       int
 	TruncComment   int
 	TruncMessage   int
@@ -60,6 +71,8 @@ type EngineSettings struct {
 	Repo           string
 	Output         string
 	Color          string
+	MaxFileBytes   int
+	NoPrefilter    bool
 }
 
 type UISettings struct {
@@ -77,6 +90,7 @@ func EngineSettingsFromOptions(opts engine.Options) EngineSettings {
 	return EngineSettings{
 		Type:           opts.Type,
 		Mode:           opts.Mode,
+		Detect:         opts.DetectMode,
 		Author:         opts.AuthorRegex,
 		Paths:          cloneStrings(opts.Paths),
 		Excludes:       cloneStrings(opts.Excludes),
@@ -84,6 +98,9 @@ func EngineSettingsFromOptions(opts engine.Options) EngineSettings {
 		ExcludeTypical: opts.ExcludeTypical,
 		WithComment:    opts.WithComment,
 		WithMessage:    opts.WithMessage,
+		IncludeStrings: opts.IncludeStrings,
+		DetectLangs:    cloneStrings(opts.DetectLangs),
+		Tags:           cloneStrings(opts.Tags),
 		TruncAll:       opts.TruncAll,
 		TruncComment:   opts.TruncComment,
 		TruncMessage:   opts.TruncMessage,
@@ -92,6 +109,8 @@ func EngineSettingsFromOptions(opts engine.Options) EngineSettings {
 		Repo:           opts.RepoDir,
 		Output:         "table",
 		Color:          "auto",
+		MaxFileBytes:   opts.MaxFileBytes,
+		NoPrefilter:    opts.NoPrefilter,
 	}
 }
 
@@ -101,6 +120,7 @@ func (s EngineSettings) ApplyToOptions(opts *engine.Options) {
 	}
 	opts.Type = s.Type
 	opts.Mode = s.Mode
+	opts.DetectMode = s.Detect
 	opts.AuthorRegex = s.Author
 	opts.Paths = cloneStrings(s.Paths)
 	opts.Excludes = cloneStrings(s.Excludes)
@@ -108,6 +128,9 @@ func (s EngineSettings) ApplyToOptions(opts *engine.Options) {
 	opts.ExcludeTypical = s.ExcludeTypical
 	opts.WithComment = s.WithComment
 	opts.WithMessage = s.WithMessage
+	opts.IncludeStrings = s.IncludeStrings
+	opts.DetectLangs = cloneStrings(s.DetectLangs)
+	opts.Tags = cloneStrings(s.Tags)
 	opts.TruncAll = s.TruncAll
 	opts.TruncComment = s.TruncComment
 	opts.TruncMessage = s.TruncMessage
@@ -116,6 +139,8 @@ func (s EngineSettings) ApplyToOptions(opts *engine.Options) {
 	if trimmed := strings.TrimSpace(s.Repo); trimmed != "" {
 		opts.RepoDir = trimmed
 	}
+	opts.MaxFileBytes = s.MaxFileBytes
+	opts.NoPrefilter = s.NoPrefilter
 }
 
 func DefaultUISettings() UISettings {

--- a/internal/detect/detect.go
+++ b/internal/detect/detect.go
@@ -1,0 +1,534 @@
+package detect
+
+import (
+	"bytes"
+	"path/filepath"
+	"strings"
+)
+
+type Info struct {
+	Name string
+}
+
+func FromPathAndContent(p string, data []byte) Info {
+	name := detectByPath(p)
+	if name != "" {
+		if strings.EqualFold(filepath.Ext(p), ".m") && name == "objective-c" && looksLikeMatlab(data) {
+			return Info{Name: ""}
+		}
+		return Info{Name: name}
+	}
+	if shebang := detectByShebang(data); shebang != "" {
+		return Info{Name: shebang}
+	}
+	return Info{Name: ""}
+}
+
+func detectByPath(p string) string {
+	base := filepath.Base(p)
+	lowerBase := strings.ToLower(base)
+	if lang, ok := basenameLanguages[lowerBase]; ok {
+		return lang
+	}
+	if lang, ok := stemLanguages[lowerBase]; ok {
+		return lang
+	}
+	ext := strings.ToLower(filepath.Ext(base))
+	if ext == "" {
+		return ""
+	}
+	if lang, ok := extensionLanguages[ext]; ok {
+		return lang
+	}
+	stem := strings.TrimSuffix(lowerBase, ext)
+	if stem == lowerBase {
+		return ""
+	}
+	if lang, ok := extensionLanguages[filepath.Ext(stem)+ext]; ok {
+		return lang
+	}
+	if lang, ok := extensionLanguages[filepath.Ext(stem)]; ok {
+		return lang
+	}
+	if lang, ok := stemLanguages[stem]; ok {
+		return lang
+	}
+	return ""
+}
+
+func detectByShebang(data []byte) string {
+	if len(data) == 0 || !bytes.HasPrefix(data, []byte("#!")) {
+		return ""
+	}
+	end := bytes.IndexByte(data, '\n')
+	if end == -1 {
+		end = len(data)
+	}
+	line := strings.ToLower(string(data[:end]))
+	for key, lang := range shebangLanguages {
+		if strings.Contains(line, key) {
+			return lang
+		}
+	}
+	return ""
+}
+
+func NormalizeLangName(name string) string {
+	n := strings.ToLower(strings.TrimSpace(name))
+	if n == "" {
+		return ""
+	}
+	if canon, ok := langAliases[n]; ok {
+		return canon
+	}
+	return n
+}
+
+func MatchesLang(info Info, allow []string) bool {
+	if len(allow) == 0 {
+		return true
+	}
+	detected := NormalizeLangName(info.Name)
+	if detected == "" {
+		return false
+	}
+	for _, raw := range allow {
+		if NormalizeLangName(raw) == detected {
+			return true
+		}
+	}
+	return false
+}
+
+func KnownLanguage(name string) bool {
+	if name == "" {
+		return false
+	}
+	_, ok := languageStyles[NormalizeLangName(name)]
+	return ok
+}
+
+var basenameLanguages = map[string]string{
+	"makefile":          "make",
+	"gnumakefile":       "make",
+	"cmakelists.txt":    "cmake",
+	"dockerfile":        "dockerfile",
+	"podfile":           "ruby",
+	"jenkinsfile":       "groovy",
+	"vagrantfile":       "ruby",
+	"justfile":          "make",
+	"procfile":          "procfile",
+	"gradle.properties": "properties",
+	"gradlew":           "bash",
+	"gradlew.bat":       "batch",
+	"gemfile":           "ruby",
+	"rakefile":          "ruby",
+	"berksfile":         "ruby",
+	"pyproject.toml":    "toml",
+	"cargo.toml":        "toml",
+	"cargo.lock":        "toml",
+	"package.json":      "json",
+	"package-lock.json": "json",
+	"composer.json":     "json",
+	"requirements.txt":  "pip",
+	"setup.py":          "python",
+	"pipfile":           "toml",
+	"pipfile.lock":      "json",
+	"pom.xml":           "xml",
+	"tsconfig.json":     "json",
+	"jsconfig.json":     "json",
+	"config.ru":         "ruby",
+}
+
+var stemLanguages = map[string]string{
+	"dockerfile":  "dockerfile",
+	"justfile":    "make",
+	"gradlew":     "bash",
+	"gradlew.bat": "batch",
+}
+
+var extensionLanguages = map[string]string{
+	".c":          "c",
+	".h":          "c",
+	".cc":         "cpp",
+	".cp":         "cpp",
+	".cpp":        "cpp",
+	".cxx":        "cpp",
+	".hh":         "cpp",
+	".hpp":        "cpp",
+	".hxx":        "cpp",
+	".m":          "objective-c",
+	".mm":         "objective-cpp",
+	".go":         "go",
+	".js":         "javascript",
+	".mjs":        "javascript",
+	".cjs":        "javascript",
+	".jsx":        "javascriptreact",
+	".ts":         "typescript",
+	".tsx":        "typescriptreact",
+	".coffee":     "coffeescript",
+	".litcoffee":  "coffeescript",
+	".py":         "python",
+	".pyw":        "python",
+	".pyi":        "python",
+	".rb":         "ruby",
+	".rake":       "ruby",
+	".gemspec":    "ruby",
+	".php":        "php",
+	".php5":       "php",
+	".phtml":      "php",
+	".cs":         "csharp",
+	".vb":         "vb",
+	".fs":         "fsharp",
+	".java":       "java",
+	".kt":         "kotlin",
+	".kts":        "kotlin",
+	".scala":      "scala",
+	".groovy":     "groovy",
+	".gradle":     "gradle",
+	".swift":      "swift",
+	".rs":         "rust",
+	".dart":       "dart",
+	".erl":        "erlang",
+	".hrl":        "erlang",
+	".ex":         "elixir",
+	".exs":        "elixir",
+	".hs":         "haskell",
+	".lhs":        "haskell",
+	".clj":        "clojure",
+	".cljs":       "clojure",
+	".cljc":       "clojure",
+	".edn":        "clojure",
+	".elm":        "elm",
+	".ml":         "ocaml",
+	".mli":        "ocaml",
+	".pas":        "pascal",
+	".adb":        "ada",
+	".ads":        "ada",
+	".sh":         "shell",
+	".bash":       "shell",
+	".zsh":        "shell",
+	".ksh":        "shell",
+	".fish":       "fish",
+	".csh":        "shell",
+	".tcsh":       "shell",
+	".ps1":        "powershell",
+	".psm1":       "powershell",
+	".psd1":       "powershell",
+	".bat":        "batch",
+	".cmd":        "batch",
+	".sql":        "sql",
+	".psql":       "sql",
+	".plsql":      "sql",
+	".pgsql":      "sql",
+	".json":       "json",
+	".json5":      "json",
+	".hjson":      "json",
+	".yaml":       "yaml",
+	".yml":        "yaml",
+	".toml":       "toml",
+	".ini":        "ini",
+	".cfg":        "ini",
+	".conf":       "ini",
+	".properties": "properties",
+	".env":        "dotenv",
+	".txt":        "text",
+	".md":         "markdown",
+	".markdown":   "markdown",
+	".mdx":        "markdown",
+	".rst":        "rst",
+	".adoc":       "asciidoc",
+	".tex":        "latex",
+	".bib":        "bibtex",
+	".html":       "html",
+	".htm":        "html",
+	".xhtml":      "html",
+	".vue":        "vue",
+	".svelte":     "svelte",
+	".xml":        "xml",
+	".svg":        "xml",
+	".plist":      "xml",
+	".xaml":       "xml",
+	".wsdl":       "xml",
+	".csproj":     "xml",
+	".fsproj":     "xml",
+	".vbproj":     "xml",
+	".sln":        "ini",
+	".css":        "css",
+	".scss":       "scss",
+	".sass":       "sass",
+	".less":       "less",
+	".styl":       "stylus",
+	".proto":      "proto",
+	".thrift":     "thrift",
+	".avdl":       "avro",
+	".graphql":    "graphql",
+	".gql":        "graphql",
+	".hcl":        "hcl",
+	".tf":         "terraform",
+	".tfvars":     "terraform",
+	".nomad":      "hcl",
+	".cue":        "cue",
+	".bzl":        "starlark",
+	".star":       "starlark",
+	".bazel":      "starlark",
+	".build":      "starlark",
+	".dockerfile": "dockerfile",
+	".mk":         "make",
+	".make":       "make",
+	".ninja":      "ninja",
+	".sqlx":       "sql",
+	".tpl":        "gotemplate",
+	".tmpl":       "gotemplate",
+	".jinja":      "jinja",
+	".jinja2":     "jinja",
+	".twig":       "twig",
+	".hbs":        "handlebars",
+	".mustache":   "handlebars",
+	".djhtml":     "django",
+	".liquid":     "liquid",
+	".pug":        "pug",
+	".jade":       "pug",
+	".haml":       "haml",
+	".ejs":        "ejs",
+	".erb":        "erb",
+	".aspx":       "aspnet",
+	".ascx":       "aspnet",
+	".cshtml":     "aspnet",
+	".vbhtml":     "aspnet",
+	".cl":         "common-lisp",
+	".lisp":       "common-lisp",
+	".scm":        "scheme",
+	".ss":         "scheme",
+	".rkt":        "racket",
+	".v":          "verilog",
+	".sv":         "systemverilog",
+	".svh":        "systemverilog",
+	".vh":         "verilog",
+	".pyx":        "cython",
+	".pxd":        "cython",
+	".pxi":        "cython",
+	".apex":       "apex",
+	".cls":        "apex",
+	".trigger":    "apex",
+	".ps1xml":     "xml",
+	".pssc":       "powershell",
+	".ahk":        "ahk",
+	".au3":        "autoit",
+	".nim":        "nim",
+	".zig":        "zig",
+	".smali":      "smali",
+	".jl":         "julia",
+	".rego":       "rego",
+	".qy":         "sql",
+}
+
+var langAliases = map[string]string{
+	"c#":       "csharp",
+	"cs":       "csharp",
+	"c++":      "cpp",
+	"cc":       "cpp",
+	"h++":      "cpp",
+	"hpp":      "cpp",
+	"hh":       "cpp",
+	"htm":      "html",
+	"js":       "javascript",
+	"mjs":      "javascript",
+	"cjs":      "javascript",
+	"jsx":      "javascriptreact",
+	"ts":       "typescript",
+	"tsx":      "typescriptreact",
+	"kt":       "kotlin",
+	"rb":       "ruby",
+	"py":       "python",
+	"ps":       "powershell",
+	"ps1":      "powershell",
+	"psm1":     "powershell",
+	"bash":     "shell",
+	"sh":       "shell",
+	"zsh":      "shell",
+	"mk":       "make",
+	"tf":       "terraform",
+	"yml":      "yaml",
+	"yaml":     "yaml",
+	"md":       "markdown",
+	"markdown": "markdown",
+	"sql":      "sql",
+}
+
+func looksLikeMatlab(data []byte) bool {
+	if len(data) == 0 {
+		return false
+	}
+	sample := data
+	if len(sample) > 4096 {
+		sample = sample[:4096]
+	}
+	lines := strings.Split(string(sample), "\n")
+	sawMatlabKeyword := false
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "%") {
+			continue
+		}
+		lower := strings.ToLower(trimmed)
+		if strings.HasPrefix(lower, "@interface") || strings.HasPrefix(lower, "@implementation") || strings.HasPrefix(lower, "#import") {
+			return false
+		}
+		if strings.HasPrefix(lower, "function") || strings.HasPrefix(lower, "classdef") {
+			return true
+		}
+		if strings.HasPrefix(lower, "properties") || strings.HasPrefix(lower, "methods") {
+			sawMatlabKeyword = true
+		}
+	}
+	return sawMatlabKeyword
+}
+
+func CanonicalDetectLangs(values []string) []string {
+	if len(values) == 0 {
+		return values
+	}
+	out := make([]string, 0, len(values))
+	seen := make(map[string]struct{}, len(values))
+	for _, raw := range values {
+		norm := NormalizeLangName(raw)
+		if norm == "" {
+			continue
+		}
+		if _, ok := seen[norm]; ok {
+			continue
+		}
+		seen[norm] = struct{}{}
+		out = append(out, norm)
+	}
+	return out
+}
+
+var shebangLanguages = map[string]string{
+	"python":        "python",
+	"python3":       "python",
+	"python2":       "python",
+	"pypy":          "python",
+	"node":          "javascript",
+	"deno":          "javascript",
+	"perl":          "perl",
+	"ruby":          "ruby",
+	"php":           "php",
+	"bash":          "shell",
+	"sh":            "shell",
+	"zsh":           "shell",
+	"ksh":           "shell",
+	"fish":          "fish",
+	"pwsh":          "powershell",
+	"powershell":    "powershell",
+	"dotnet-script": "csharp",
+	"lua":           "lua",
+	"groovy":        "groovy",
+	"swift":         "swift",
+	"r":             "r",
+	"scheme":        "scheme",
+	"guile":         "scheme",
+	"awk":           "awk",
+	"sed":           "sed",
+	"elixir":        "elixir",
+	"escript":       "erlang",
+}
+
+var languageStyles = map[string]struct{}{
+	"c":               {},
+	"cpp":             {},
+	"objective-c":     {},
+	"objective-cpp":   {},
+	"go":              {},
+	"javascript":      {},
+	"javascriptreact": {},
+	"typescript":      {},
+	"typescriptreact": {},
+	"coffeescript":    {},
+	"python":          {},
+	"ruby":            {},
+	"php":             {},
+	"csharp":          {},
+	"vb":              {},
+	"fsharp":          {},
+	"java":            {},
+	"kotlin":          {},
+	"scala":           {},
+	"groovy":          {},
+	"swift":           {},
+	"rust":            {},
+	"dart":            {},
+	"erlang":          {},
+	"elixir":          {},
+	"haskell":         {},
+	"clojure":         {},
+	"elm":             {},
+	"ocaml":           {},
+	"pascal":          {},
+	"ada":             {},
+	"shell":           {},
+	"fish":            {},
+	"powershell":      {},
+	"batch":           {},
+	"sql":             {},
+	"json":            {},
+	"yaml":            {},
+	"toml":            {},
+	"ini":             {},
+	"properties":      {},
+	"dotenv":          {},
+	"markdown":        {},
+	"rst":             {},
+	"asciidoc":        {},
+	"latex":           {},
+	"html":            {},
+	"vue":             {},
+	"svelte":          {},
+	"xml":             {},
+	"css":             {},
+	"scss":            {},
+	"sass":            {},
+	"less":            {},
+	"stylus":          {},
+	"proto":           {},
+	"thrift":          {},
+	"graphql":         {},
+	"hcl":             {},
+	"terraform":       {},
+	"cue":             {},
+	"starlark":        {},
+	"dockerfile":      {},
+	"make":            {},
+	"ninja":           {},
+	"gotemplate":      {},
+	"jinja":           {},
+	"twig":            {},
+	"handlebars":      {},
+	"django":          {},
+	"liquid":          {},
+	"pug":             {},
+	"haml":            {},
+	"ejs":             {},
+	"erb":             {},
+	"aspnet":          {},
+	"common-lisp":     {},
+	"scheme":          {},
+	"racket":          {},
+	"verilog":         {},
+	"systemverilog":   {},
+	"cython":          {},
+	"apex":            {},
+	"ahk":             {},
+	"autoit":          {},
+	"nim":             {},
+	"zig":             {},
+	"smali":           {},
+	"julia":           {},
+	"rego":            {},
+	"text":            {},
+	"pip":             {},
+	"gradle":          {},
+	"cmake":           {},
+	"procfile":        {},
+}

--- a/internal/detect/detect_test.go
+++ b/internal/detect/detect_test.go
@@ -1,0 +1,48 @@
+package detect
+
+import "testing"
+
+func TestNormalizeLangNameAliases(t *testing.T) {
+	cases := map[string]string{
+		"JS":   "javascript",
+		"Ts":   "typescript",
+		"c++":  "cpp",
+		"Py":   "python",
+		"bash": "shell",
+	}
+	for input, want := range cases {
+		if got := NormalizeLangName(input); got != want {
+			t.Fatalf("NormalizeLangName(%q)=%q want %q", input, got, want)
+		}
+	}
+}
+
+func TestCanonicalDetectLangsDedupes(t *testing.T) {
+	in := []string{" js ", "TS", "js", "PY"}
+	got := CanonicalDetectLangs(in)
+	want := []string{"javascript", "typescript", "python"}
+	if len(got) != len(want) {
+		t.Fatalf("unexpected length: got=%v want=%v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("value mismatch at %d: got=%q want=%q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestFromPathAndContentMatlabHeuristic(t *testing.T) {
+	data := []byte("% comment\nfunction y = square(x)\ny = x.^2;\nend\n")
+	info := FromPathAndContent("foo.m", data)
+	if info.Name != "" {
+		t.Fatalf("expected matlab-like .m files to fall back, got %q", info.Name)
+	}
+}
+
+func TestFromPathAndContentObjectiveCPreferred(t *testing.T) {
+	data := []byte("#import <Foundation/Foundation.h>\n@interface Foo : NSObject\n@end\n")
+	info := FromPathAndContent("bar.m", data)
+	if info.Name != "objective-c" {
+		t.Fatalf("expected objective-c heuristics to remain, got %q", info.Name)
+	}
+}

--- a/internal/engine/detect_parse.go
+++ b/internal/engine/detect_parse.go
@@ -1,0 +1,666 @@
+package engine
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"unicode/utf8"
+
+	"github.com/phyten/todox/internal/detect"
+	"github.com/phyten/todox/internal/model"
+)
+
+type detectionMode int
+
+const (
+	detectionModeRegex detectionMode = iota
+	detectionModeParse
+	detectionModeAuto
+)
+
+type commentStyle struct {
+	linePrefixes []string
+	block        []blockPattern
+	stringDelims []string
+}
+
+type blockPattern struct {
+	start              string
+	end                string
+	kind               model.MatchKind
+	allowIndentedStart bool
+}
+
+type parseJob struct {
+	path string
+}
+
+type parseResult struct {
+	matches []model.Match
+	errs    []ItemError
+}
+
+type tagSpec struct {
+	raw   string
+	upper string
+}
+
+func collectMatches(ctx context.Context, opts Options, searchTags []string) ([]model.Match, []ItemError, error) {
+	var mode detectionMode
+	switch strings.ToLower(strings.TrimSpace(opts.DetectMode)) {
+	case "", "auto":
+		mode = detectionModeAuto
+	case "regex":
+		mode = detectionModeRegex
+	case "parse":
+		mode = detectionModeParse
+	default:
+		return nil, nil, fmt.Errorf("invalid detect mode: %s", opts.DetectMode)
+	}
+	switch mode {
+	case detectionModeRegex:
+		matches, errs, err := collectMatchesRegex(opts, searchTags)
+		return matches, errs, err
+	case detectionModeParse:
+		return collectMatchesParse(ctx, opts, searchTags, false)
+	case detectionModeAuto:
+		return collectMatchesParse(ctx, opts, searchTags, true)
+	default:
+		return nil, nil, fmt.Errorf("unknown detect mode")
+	}
+}
+
+func collectMatchesRegex(opts Options, tags []string) ([]model.Match, []ItemError, error) {
+	pattern := patternForTags(tags)
+	matches, err := gitGrepMatches(opts.RepoDir, pattern, opts.Paths, opts.Excludes, opts.ExcludeTypical)
+	if err != nil {
+		return nil, nil, err
+	}
+	matches = filterByPathRegex(matches, opts.PathRegexCompiled)
+	// refine tags inside each match (multiple per line)
+	expanded := expandLineMatches(matches, tags)
+	return expanded, nil, nil
+}
+
+func collectMatchesParse(ctx context.Context, opts Options, tags []string, allowFallback bool) ([]model.Match, []ItemError, error) {
+	pattern := patternForTags(tags)
+	var candidateFiles []string
+	var err error
+	if opts.NoPrefilter {
+		candidateFiles, err = gitListFiles(opts.RepoDir, opts.Paths, opts.Excludes, opts.ExcludeTypical)
+	} else {
+		candidateFiles, err = gitGrepFiles(opts.RepoDir, pattern, opts.Paths, opts.Excludes, opts.ExcludeTypical)
+	}
+	if err != nil {
+		return nil, nil, err
+	}
+	candidateFiles = filterPathsByRegex(candidateFiles, opts.PathRegexCompiled)
+	if len(candidateFiles) == 0 {
+		return nil, nil, nil
+	}
+	tagsSpec := normalizeTags(tags)
+
+	jobs := make(chan parseJob)
+	results := make(chan parseResult)
+
+	workers := opts.Jobs
+	if workers < 1 {
+		workers = 1
+	}
+	if workers > 64 {
+		workers = 64
+	}
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for i := 0; i < workers; i++ {
+		go func() {
+			defer wg.Done()
+			for job := range jobs {
+				select {
+				case <-ctx.Done():
+					return
+				default:
+				}
+				matches, errs := parseFile(job.path, opts, tagsSpec, allowFallback)
+				results <- parseResult{matches: matches, errs: errs}
+			}
+		}()
+	}
+
+	go func() {
+		defer close(jobs)
+		for _, path := range candidateFiles {
+			select {
+			case <-ctx.Done():
+				return
+			case jobs <- parseJob{path: path}:
+			}
+		}
+	}()
+
+	go func() {
+		wg.Wait()
+		close(results)
+	}()
+
+	var all []model.Match
+	var errs []ItemError
+	for res := range results {
+		if len(res.matches) > 0 {
+			all = append(all, res.matches...)
+		}
+		if len(res.errs) > 0 {
+			errs = append(errs, res.errs...)
+		}
+	}
+	sort.SliceStable(all, func(i, j int) bool {
+		if all[i].File == all[j].File {
+			if all[i].Span.StartLine == all[j].Span.StartLine {
+				return all[i].Span.StartCol < all[j].Span.StartCol
+			}
+			return all[i].Span.StartLine < all[j].Span.StartLine
+		}
+		return all[i].File < all[j].File
+	})
+	sort.SliceStable(errs, func(i, j int) bool {
+		if errs[i].File == errs[j].File {
+			if errs[i].Line == errs[j].Line {
+				return errs[i].Stage < errs[j].Stage
+			}
+			return errs[i].Line < errs[j].Line
+		}
+		return errs[i].File < errs[j].File
+	})
+	return all, errs, nil
+}
+
+func parseFile(relPath string, opts Options, tags []tagSpec, allowFallback bool) ([]model.Match, []ItemError) {
+	full := filepath.Join(opts.RepoDir, relPath)
+	data, err := os.ReadFile(full)
+	if err != nil {
+		return nil, []ItemError{newItemError(relPath, 0, "read", err)}
+	}
+	if bytes.IndexByte(data, 0) >= 0 {
+		return nil, nil
+	}
+	if !utf8.Valid(data) {
+		matches := scanPlainText(relPath, data, tags)
+		return matches, nil
+	}
+	if opts.MaxFileBytes > 0 && len(data) > opts.MaxFileBytes {
+		matches := scanPlainText(relPath, data, tags)
+		return matches, nil
+	}
+	info := detect.FromPathAndContent(relPath, data)
+	if len(opts.DetectLangs) > 0 && !detect.MatchesLang(info, opts.DetectLangs) {
+		if allowFallback {
+			return scanPlainText(relPath, data, tags), nil
+		}
+		return nil, nil
+	}
+	style, ok := styleForLanguage(detect.NormalizeLangName(info.Name))
+	if !ok {
+		if allowFallback {
+			return scanPlainText(relPath, data, tags), nil
+		}
+		return nil, nil
+	}
+	matches := scanWithStyle(relPath, data, tags, info.Name, style, opts.IncludeStrings)
+	if allowFallback && len(matches) == 0 {
+		fallback := scanPlainText(relPath, data, tags)
+		if len(fallback) > 0 {
+			return fallback, nil
+		}
+	}
+	return matches, nil
+}
+
+func normalizeTags(tags []string) []tagSpec {
+	eff := effectiveTags(tags)
+	out := make([]tagSpec, 0, len(eff))
+	for _, tag := range eff {
+		upper := strings.ToUpper(tag)
+		out = append(out, tagSpec{raw: tag, upper: upper})
+	}
+	return out
+}
+
+func scanWithStyle(path string, data []byte, tags []tagSpec, lang string, style commentStyle, includeStrings bool) []model.Match {
+	if len(data) == 0 {
+		return nil
+	}
+	lineOffsets := computeLineOffsets(data)
+	var matches []model.Match
+
+	type blockState struct {
+		pattern     blockPattern
+		startOffset int
+		buffer      bytes.Buffer
+	}
+
+	var state *blockState
+	scanner := bufio.NewScanner(bytes.NewReader(data))
+	// allow very long lines
+	buf := make([]byte, 0, 1024*16)
+	scanner.Buffer(buf, len(data)+1)
+	offset := 0
+	for scanner.Scan() {
+		lineBytes := scanner.Bytes()
+		line := string(lineBytes)
+		lineLen := len(lineBytes)
+		lineEnd := offset + lineLen
+		if state != nil {
+			state.buffer.Write(lineBytes)
+			state.buffer.WriteByte('\n')
+			if idx := strings.Index(state.buffer.String(), state.pattern.end); idx >= 0 {
+				content := state.buffer.String()
+				endIdx := strings.Index(content, state.pattern.end)
+				if endIdx >= 0 {
+					inner := content[:endIdx]
+					blockMatches := findMatchesInText(path, inner, tags, lang, state.pattern.kind, state.startOffset, lineOffsets)
+					matches = append(matches, blockMatches...)
+				}
+				state = nil
+			}
+			if lineEnd < len(data) && data[lineEnd] == '\n' {
+				offset = lineEnd + 1
+			} else {
+				offset = lineEnd
+			}
+			continue
+		}
+
+		// block start detection
+		started := false
+		for _, block := range style.block {
+			if idx := indexBlockStart(line, block); idx >= 0 {
+				state = &blockState{pattern: block, startOffset: offset + idx + len(block.start)}
+				remainder := line[idx+len(block.start):] + "\n"
+				state.buffer.WriteString(remainder)
+				started = true
+				break
+			}
+		}
+		if started {
+			if lineEnd < len(data) && data[lineEnd] == '\n' {
+				offset = lineEnd + 1
+			} else {
+				offset = lineEnd
+			}
+			continue
+		}
+
+		// line comments
+		for _, prefix := range style.linePrefixes {
+			idx := strings.Index(line, prefix)
+			if idx >= 0 {
+				commentText := line[idx+len(prefix):]
+				if mt := findMatchesInText(path, commentText, tags, lang, model.MatchKindComment, offset+idx+len(prefix), lineOffsets); len(mt) > 0 {
+					matches = append(matches, mt...)
+				}
+				break
+			}
+		}
+
+		if includeStrings {
+			for _, delim := range style.stringDelims {
+				pos := 0
+				for pos < len(line) {
+					idx := strings.Index(line[pos:], delim)
+					if idx < 0 {
+						break
+					}
+					start := pos + idx
+					if len(delim) == 1 && isEscaped(line, start) {
+						pos = start + len(delim)
+						continue
+					}
+					contentStart := start + len(delim)
+					end := findClosingDelimiter(line, contentStart, delim)
+					if end < 0 {
+						break
+					}
+					inner := line[contentStart:end]
+					mt := findMatchesInText(path, inner, tags, lang, model.MatchKindString, offset+contentStart, lineOffsets)
+					if len(mt) > 0 {
+						matches = append(matches, mt...)
+					}
+					pos = end + len(delim)
+				}
+			}
+		}
+
+		if lineEnd < len(data) && data[lineEnd] == '\n' {
+			offset = lineEnd + 1
+		} else {
+			offset = lineEnd
+		}
+	}
+
+	if err := scanner.Err(); err != nil && !errors.Is(err, bufio.ErrTooLong) {
+		return matches
+	}
+	if state != nil {
+		content := state.buffer.String()
+		blockMatches := findMatchesInText(path, content, tags, lang, state.pattern.kind, state.startOffset, lineOffsets)
+		matches = append(matches, blockMatches...)
+	}
+	return matches
+}
+
+func indexBlockStart(line string, block blockPattern) int {
+	if block.allowIndentedStart {
+		trimmed := strings.TrimLeft(line, " \t")
+		if strings.HasPrefix(trimmed, block.start) {
+			return len(line) - len(trimmed)
+		}
+		return -1
+	}
+	return strings.Index(line, block.start)
+}
+
+func findClosingDelimiter(line string, start int, delim string) int {
+	if len(delim) == 0 {
+		return -1
+	}
+	if len(delim) == 1 {
+		target := delim[0]
+		for i := start; i < len(line); i++ {
+			if line[i] != target {
+				continue
+			}
+			if isEscaped(line, i) {
+				continue
+			}
+			return i
+		}
+		return -1
+	}
+	idx := strings.Index(line[start:], delim)
+	if idx < 0 {
+		return -1
+	}
+	return start + idx
+}
+
+func isEscaped(line string, pos int) bool {
+	if pos == 0 {
+		return false
+	}
+	count := 0
+	for i := pos - 1; i >= 0; i-- {
+		if line[i] != '\\' {
+			break
+		}
+		count++
+	}
+	return count%2 == 1
+}
+
+func scanPlainText(path string, data []byte, tags []tagSpec) []model.Match {
+	lineOffsets := computeLineOffsets(data)
+	var matches []model.Match
+	scanner := bufio.NewScanner(bytes.NewReader(data))
+	buf := make([]byte, 0, 1024*8)
+	scanner.Buffer(buf, len(data)+1)
+	offset := 0
+	for scanner.Scan() {
+		lineBytes := scanner.Bytes()
+		text := string(lineBytes)
+		mt := findMatchesInText(path, text, tags, "", model.MatchKindUnknown, offset, lineOffsets)
+		if len(mt) > 0 {
+			matches = append(matches, mt...)
+		}
+		offset += len(lineBytes) + 1
+	}
+	return matches
+}
+
+func findMatchesInText(path string, text string, tags []tagSpec, lang string, kind model.MatchKind, baseOffset int, lineOffsets []int) []model.Match {
+	if strings.TrimSpace(text) == "" {
+		return nil
+	}
+	upper := strings.ToUpper(text)
+	var hits []struct {
+		idx int
+		tag tagSpec
+	}
+	for _, tag := range tags {
+		searchFrom := 0
+		for {
+			pos := strings.Index(upper[searchFrom:], tag.upper)
+			if pos < 0 {
+				break
+			}
+			abs := searchFrom + pos
+			hits = append(hits, struct {
+				idx int
+				tag tagSpec
+			}{idx: abs, tag: tag})
+			searchFrom = abs + len(tag.upper)
+		}
+	}
+	if len(hits) == 0 {
+		return nil
+	}
+	sort.Slice(hits, func(i, j int) bool { return hits[i].idx < hits[j].idx })
+	matches := make([]model.Match, 0, len(hits))
+	for _, hit := range hits {
+		byteStart := baseOffset + hit.idx
+		span := spanFromOffset(byteStart, len(hit.tag.raw), lineOffsets)
+		matches = append(matches, model.Match{
+			File: path,
+			Lang: detect.NormalizeLangName(lang),
+			Kind: kind,
+			Tag:  hit.tag.upper,
+			Text: strings.TrimSpace(text),
+			Span: span,
+		})
+	}
+	return matches
+}
+
+func spanFromOffset(start, length int, lineOffsets []int) model.Span {
+	line, col := lineColFromOffset(start, lineOffsets)
+	endLine, endCol := lineColFromOffset(start+length, lineOffsets)
+	return model.Span{
+		StartLine: line,
+		StartCol:  col,
+		EndLine:   endLine,
+		EndCol:    endCol,
+		ByteStart: start,
+		ByteEnd:   start + length,
+	}
+}
+
+func lineColFromOffset(offset int, lineOffsets []int) (line, col int) {
+	idx := sort.Search(len(lineOffsets), func(i int) bool { return lineOffsets[i] > offset })
+	if idx == 0 {
+		return 1, offset + 1
+	}
+	lineStart := lineOffsets[idx-1]
+	return idx, offset - lineStart + 1
+}
+
+func computeLineOffsets(data []byte) []int {
+	offsets := make([]int, 0, bytes.Count(data, []byte{'\n'})+2)
+	offsets = append(offsets, 0)
+	for i, b := range data {
+		if b == '\n' {
+			offsets = append(offsets, i+1)
+		}
+	}
+	if offsets[len(offsets)-1] != len(data) {
+		offsets = append(offsets, len(data))
+	}
+	return offsets
+}
+
+func filterPathsByRegex(paths []string, rx []*regexp.Regexp) []string {
+	if len(rx) == 0 {
+		return paths
+	}
+	out := make([]string, 0, len(paths))
+	for _, p := range paths {
+		if matchAny(rx, p) {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+func matchAny(rx []*regexp.Regexp, text string) bool {
+	if len(rx) == 0 {
+		return true
+	}
+	for _, r := range rx {
+		if r.MatchString(text) {
+			return true
+		}
+	}
+	return false
+}
+
+func gitGrepMatches(repo, pattern string, includes, excludes []string, typical bool) ([]match, error) {
+	pathspecs := buildGrepPathspecs(includes, excludes, typical)
+	args := []string{"-c", "core.quotePath=false", "grep", "-nI", "--no-color", "-i", "-E", pattern, "--"}
+	args = append(args, pathspecs...)
+	cmd := exec.Command("git", args...)
+	cmd.Dir = repo
+	out, err := cmd.Output()
+	if err != nil {
+		var ee *exec.ExitError
+		if errors.As(err, &ee) && ee.ExitCode() == 1 {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("git grep: %w", err)
+	}
+	var res []match
+	sc := bufio.NewScanner(bytes.NewReader(out))
+	buf := make([]byte, 0, 1024*1024)
+	sc.Buffer(buf, 1024*1024)
+	for sc.Scan() {
+		line := sc.Text()
+		loc := reLine.FindStringIndex(line)
+		if loc == nil {
+			continue
+		}
+		file := line[:loc[0]]
+		lineStr := line[loc[0]+1 : loc[1]-1]
+		text := line[loc[1]:]
+		n, _ := strconv.Atoi(lineStr)
+		file = filepath.ToSlash(file)
+		res = append(res, match{file: file, line: n, text: text})
+	}
+	if err := sc.Err(); err != nil {
+		return nil, fmt.Errorf("git grep scan: %w", err)
+	}
+	return res, nil
+}
+
+func gitGrepFiles(repo, pattern string, includes, excludes []string, typical bool) ([]string, error) {
+	pathspecs := buildGrepPathspecs(includes, excludes, typical)
+	args := []string{"-c", "core.quotePath=false", "grep", "-Ilz", "-i", "-E", pattern, "--"}
+	args = append(args, pathspecs...)
+	cmd := exec.Command("git", args...)
+	cmd.Dir = repo
+	out, err := cmd.Output()
+	if err != nil {
+		var ee *exec.ExitError
+		if errors.As(err, &ee) && ee.ExitCode() == 1 {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("git grep -l: %w", err)
+	}
+	if len(out) == 0 {
+		return nil, nil
+	}
+	parts := bytes.Split(out, []byte{0})
+	paths := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if len(p) == 0 {
+			continue
+		}
+		paths = append(paths, filepath.ToSlash(string(p)))
+	}
+	return paths, nil
+}
+
+func gitListFiles(repo string, includes, excludes []string, typical bool) ([]string, error) {
+	args := []string{"ls-files", "-z"}
+	args = append(args, buildGrepPathspecs(includes, excludes, typical)...)
+	cmd := exec.Command("git", args...)
+	cmd.Dir = repo
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("git ls-files: %w", err)
+	}
+	if len(out) == 0 {
+		return nil, nil
+	}
+	parts := bytes.Split(out, []byte{0})
+	paths := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if len(p) == 0 {
+			continue
+		}
+		paths = append(paths, filepath.ToSlash(string(p)))
+	}
+	return paths, nil
+}
+
+func expandLineMatches(matches []match, tags []string) []model.Match {
+	specs := normalizeTags(tags)
+	out := make([]model.Match, 0, len(matches))
+	for _, m := range matches {
+		text := m.text
+		mt := findMatchesInText(m.file, text, specs, "", model.MatchKindUnknown, 0, []int{0})
+		if len(mt) == 0 {
+			// fallback to original line-level match
+			clean := strings.TrimRight(text, "\r\n")
+			tag := kindOf(clean, tags)
+			if tag == "UNKNOWN" {
+				tag = ""
+			}
+			width := utf8.RuneCountInString(clean)
+			if width == 0 {
+				width = len(clean)
+			}
+			if width < 1 {
+				width = 1
+			}
+			out = append(out, model.Match{
+				File: m.file,
+				Lang: "",
+				Kind: model.MatchKindUnknown,
+				Tag:  tag,
+				Text: strings.TrimSpace(text),
+				Span: model.Span{StartLine: m.line, EndLine: m.line, StartCol: 1, EndCol: width, ByteStart: 0, ByteEnd: len(clean)},
+			})
+			continue
+		}
+		for i := range mt {
+			mt[i].File = m.file
+			mt[i].Span.StartLine = m.line
+			mt[i].Span.EndLine = m.line
+			if mt[i].Span.StartCol <= 0 {
+				mt[i].Span.StartCol = 1
+			}
+			if mt[i].Span.EndCol <= 0 {
+				mt[i].Span.EndCol = mt[i].Span.StartCol + len(mt[i].Tag)
+			}
+		}
+		out = append(out, mt...)
+	}
+	return out
+}

--- a/internal/engine/detect_parse_test.go
+++ b/internal/engine/detect_parse_test.go
@@ -1,0 +1,249 @@
+package engine
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/phyten/todox/internal/model"
+)
+
+func TestExpandLineMatchesRespectsLineNumbers(t *testing.T) {
+	matches := []match{
+		{file: "foo.txt", line: 5, text: "    // todo lower"},
+		{file: "foo.txt", line: 11, text: "    # FIXME upper"},
+	}
+	out := expandLineMatches(matches, []string{"TODO", "FIXME"})
+	if len(out) != 2 {
+		t.Fatalf("expected 2 matches, got %d", len(out))
+	}
+	if out[0].Span.StartLine != 5 {
+		t.Fatalf("first match line mismatch: got %d want %d", out[0].Span.StartLine, 5)
+	}
+	if out[1].Span.StartLine != 11 {
+		t.Fatalf("second match line mismatch: got %d want %d", out[1].Span.StartLine, 11)
+	}
+}
+
+func TestExpandLineMatchesFallbackUsesKindOf(t *testing.T) {
+	matches := []match{
+		{file: "foo.txt", line: 3, text: "no markers here"},
+	}
+	out := expandLineMatches(matches, []string{"TODO"})
+	if len(out) != 1 {
+		t.Fatalf("expected 1 match, got %d", len(out))
+	}
+	if out[0].Span.StartLine != 3 || out[0].Span.EndLine != 3 {
+		t.Fatalf("unexpected span lines: %d-%d", out[0].Span.StartLine, out[0].Span.EndLine)
+	}
+	if out[0].Tag != "" {
+		t.Fatalf("expected empty tag for fallback, got %q", out[0].Tag)
+	}
+	if out[0].Span.StartCol != 1 {
+		t.Fatalf("expected start column 1, got %d", out[0].Span.StartCol)
+	}
+	if out[0].Span.EndCol < out[0].Span.StartCol {
+		t.Fatalf("end column should not be less than start: %d < %d", out[0].Span.EndCol, out[0].Span.StartCol)
+	}
+}
+
+func TestGitGrepCaseInsensitive(t *testing.T) {
+	repo := t.TempDir()
+	runGit := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = repo
+		cmd.Env = append(os.Environ(), "GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_SYSTEM=/dev/null")
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("git %s failed: %v\n%s", strings.Join(args, " "), err, out)
+		}
+	}
+
+	runGit("init")
+	lower := filepath.Join(repo, "notes.txt")
+	if err := os.WriteFile(lower, []byte("this line has todo in lowercase\n"), 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	runGit("add", "notes.txt")
+
+	pattern := "(TODO|FIXME)"
+	matches, err := gitGrepMatches(repo, pattern, nil, nil, false)
+	if err != nil {
+		t.Fatalf("gitGrepMatches error: %v", err)
+	}
+	if len(matches) != 1 {
+		t.Fatalf("expected 1 match, got %d", len(matches))
+	}
+	if matches[0].line != 1 {
+		t.Fatalf("unexpected line number: got %d want 1", matches[0].line)
+	}
+
+	files, err := gitGrepFiles(repo, pattern, nil, nil, false)
+	if err != nil {
+		t.Fatalf("gitGrepFiles error: %v", err)
+	}
+	if len(files) != 1 {
+		t.Fatalf("expected 1 file, got %d", len(files))
+	}
+	if files[0] != "notes.txt" {
+		t.Fatalf("unexpected file: got %s want notes.txt", files[0])
+	}
+}
+
+func TestScanWithStyleHandlesEscapedQuotes(t *testing.T) {
+	tags := normalizeTags([]string{"TODO"})
+	data := []byte(`const s = "escaped \"TODO\" marker"` + "\n")
+	matches := scanWithStyle("app.js", data, tags, "javascript", styleJS, true)
+	if len(matches) != 1 {
+		t.Fatalf("expected 1 match, got %d", len(matches))
+	}
+	if matches[0].Kind != model.MatchKindString {
+		t.Fatalf("expected string kind, got %s", matches[0].Kind)
+	}
+}
+
+func TestScanWithStyleHandlesTemplateBlocks(t *testing.T) {
+	tags := normalizeTags([]string{"TODO"})
+	data := []byte("const tpl = `\nTODO inside template\n`;\n")
+	matches := scanWithStyle("app.ts", data, tags, "typescript", styleJS, true)
+	if len(matches) != 1 {
+		t.Fatalf("expected 1 match, got %d", len(matches))
+	}
+	span := matches[0].Span
+	if span.StartLine != 2 || span.EndLine != 2 {
+		t.Fatalf("template literal span mismatch: %v", span)
+	}
+	if matches[0].Kind != model.MatchKindString {
+		t.Fatalf("expected string kind, got %s", matches[0].Kind)
+	}
+}
+
+func TestScanWithStyleGoRawStringMultiline(t *testing.T) {
+	tags := normalizeTags([]string{"TODO"})
+	data := []byte("value := `\nTODO inside raw string\n`\n")
+	matches := scanWithStyle("main.go", data, tags, "go", styleGo, true)
+	if len(matches) != 1 {
+		t.Fatalf("expected 1 match, got %d", len(matches))
+	}
+	if matches[0].Kind != model.MatchKindString {
+		t.Fatalf("expected string kind, got %s", matches[0].Kind)
+	}
+	if matches[0].Span.StartLine != 2 || matches[0].Span.EndLine != 2 {
+		t.Fatalf("unexpected span: %+v", matches[0].Span)
+	}
+}
+
+func TestScanWithStyleRubyIndentedBlock(t *testing.T) {
+	tags := normalizeTags([]string{"TODO"})
+	data := []byte("  =begin\n  TODO: fix\n  =end\n")
+	matches := scanWithStyle("note.rb", data, tags, "ruby", styleRuby, false)
+	if len(matches) != 1 {
+		t.Fatalf("expected 1 match, got %d", len(matches))
+	}
+	if matches[0].Kind != model.MatchKindComment {
+		t.Fatalf("expected comment kind, got %s", matches[0].Kind)
+	}
+	if matches[0].Span.StartLine != 2 {
+		t.Fatalf("expected start line 2, got %d", matches[0].Span.StartLine)
+	}
+}
+
+func TestScanWithStyleSQLStrings(t *testing.T) {
+	tags := normalizeTags([]string{"TODO"})
+	data := []byte("SELECT 'todo fix';\n")
+	matches := scanWithStyle("query.sql", data, tags, "sql", styleSQL, true)
+	if len(matches) != 1 {
+		t.Fatalf("expected 1 match, got %d", len(matches))
+	}
+	if matches[0].Kind != model.MatchKindString {
+		t.Fatalf("expected string kind, got %s", matches[0].Kind)
+	}
+}
+
+func TestParseFileDetectLangsFallback(t *testing.T) {
+	dir := t.TempDir()
+	rel := "app.js"
+	content := []byte("const x = 1; // TODO check\n")
+	if err := os.WriteFile(filepath.Join(dir, rel), content, 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	opts := Options{RepoDir: dir, DetectLangs: []string{"go"}, IncludeStrings: true}
+	tags := normalizeTags([]string{"TODO"})
+	if matches, _ := parseFile(rel, opts, tags, false); len(matches) != 0 {
+		t.Fatalf("expected skip without fallback, got %d", len(matches))
+	}
+	if matches, _ := parseFile(rel, opts, tags, true); len(matches) == 0 {
+		t.Fatalf("expected fallback matches, got 0")
+	}
+}
+
+func TestParseFileMaxFileBytesFallback(t *testing.T) {
+	dir := t.TempDir()
+	rel := "big.txt"
+	content := strings.Repeat("x", 1024) + " TODO large\n"
+	if err := os.WriteFile(filepath.Join(dir, rel), []byte(content), 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	opts := Options{RepoDir: dir, MaxFileBytes: 16}
+	tags := normalizeTags([]string{"TODO"})
+	matches, _ := parseFile(rel, opts, tags, false)
+	if len(matches) == 0 {
+		t.Fatalf("expected fallback matches, got 0")
+	}
+	if matches[0].Kind != model.MatchKindUnknown {
+		t.Fatalf("expected unknown kind from plain-text fallback, got %s", matches[0].Kind)
+	}
+}
+
+func TestParseFileSkipsBinary(t *testing.T) {
+	dir := t.TempDir()
+	rel := "blob.bin"
+	content := []byte{0x00, 0x01, 0x02, 0x03}
+	if err := os.WriteFile(filepath.Join(dir, rel), content, 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	opts := Options{RepoDir: dir}
+	tags := normalizeTags([]string{"TODO"})
+	if matches, _ := parseFile(rel, opts, tags, true); len(matches) != 0 {
+		t.Fatalf("expected no matches for binary file, got %d", len(matches))
+	}
+}
+
+func TestScanWithStylePythonTripleQuoteSpan(t *testing.T) {
+	tags := normalizeTags([]string{"TODO"})
+	data := []byte("\"\"\"\nTODO item\n\"\"\"\n")
+	matches := scanWithStyle("note.py", data, tags, "python", stylePython, true)
+	if len(matches) != 1 {
+		t.Fatalf("expected 1 match, got %d", len(matches))
+	}
+	span := matches[0].Span
+	if span.StartLine != 2 || span.EndLine != 2 {
+		t.Fatalf("unexpected span lines: %d-%d", span.StartLine, span.EndLine)
+	}
+	if span.StartCol != 1 {
+		t.Fatalf("expected column 1, got %d", span.StartCol)
+	}
+}
+
+func TestComputeLineOffsetsNoDuplicateSentinel(t *testing.T) {
+	cases := []struct {
+		name string
+		data string
+		want []int
+	}{
+		{name: "with trailing newline", data: "a\nbc\n", want: []int{0, 2, 5}},
+		{name: "without trailing newline", data: "a\n", want: []int{0, 2}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := computeLineOffsets([]byte(tc.data))
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("computeLineOffsets mismatch: got=%v want=%v", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/engine/detect_styles.go
+++ b/internal/engine/detect_styles.go
@@ -1,0 +1,179 @@
+package engine
+
+import "github.com/phyten/todox/internal/model"
+
+var (
+	styleC = commentStyle{
+		linePrefixes: []string{"//"},
+		block:        []blockPattern{{start: "/*", end: "*/", kind: model.MatchKindComment}},
+		stringDelims: []string{"\""},
+	}
+	styleGo = commentStyle{
+		linePrefixes: []string{"//"},
+		block:        []blockPattern{{start: "/*", end: "*/", kind: model.MatchKindComment}, {start: "`", end: "`", kind: model.MatchKindString}},
+		stringDelims: []string{"\""},
+	}
+	styleJS = commentStyle{
+		linePrefixes: []string{"//"},
+		block:        []blockPattern{{start: "/*", end: "*/", kind: model.MatchKindComment}, {start: "`", end: "`", kind: model.MatchKindString}},
+		stringDelims: []string{"\"", "'"},
+	}
+	styleHash = commentStyle{
+		linePrefixes: []string{"#"},
+		stringDelims: []string{"\"", "'"},
+	}
+	styleRuby = commentStyle{
+		linePrefixes: []string{"#"},
+		block:        []blockPattern{{start: "=begin", end: "=end", kind: model.MatchKindComment, allowIndentedStart: true}},
+		stringDelims: []string{"\"", "'"},
+	}
+	stylePython = commentStyle{
+		linePrefixes: []string{"#"},
+		block:        []blockPattern{{start: "\"\"\"", end: "\"\"\"", kind: model.MatchKindString}, {start: "'''", end: "'''", kind: model.MatchKindString}},
+		stringDelims: []string{"\"", "'"},
+	}
+	styleHTML = commentStyle{
+		block: []blockPattern{{start: "<!--", end: "-->", kind: model.MatchKindComment}},
+	}
+	styleSQL = commentStyle{
+		linePrefixes: []string{"--"},
+		block:        []blockPattern{{start: "/*", end: "*/", kind: model.MatchKindComment}},
+		stringDelims: []string{"'"},
+	}
+	styleCSS = commentStyle{
+		block: []blockPattern{{start: "/*", end: "*/", kind: model.MatchKindComment}},
+	}
+	styleIni = commentStyle{
+		linePrefixes: []string{";", "#"},
+	}
+	styleHCL = commentStyle{
+		linePrefixes: []string{"//", "#"},
+		block:        []blockPattern{{start: "/*", end: "*/", kind: model.MatchKindComment}},
+	}
+	styleLisp = commentStyle{
+		linePrefixes: []string{";"},
+	}
+	styleHaskell = commentStyle{
+		linePrefixes: []string{"--"},
+		block:        []blockPattern{{start: "{-", end: "-}", kind: model.MatchKindComment}},
+	}
+	stylePowershell = commentStyle{
+		linePrefixes: []string{"#"},
+		block:        []blockPattern{{start: "<#", end: "#>", kind: model.MatchKindComment}},
+	}
+	styleJinja = commentStyle{
+		block: []blockPattern{{start: "{#", end: "#}", kind: model.MatchKindComment}},
+	}
+	styleTwig       = styleJinja
+	styleHandlebars = commentStyle{
+		block: []blockPattern{{start: "{{!--", end: "--}}", kind: model.MatchKindComment}, {start: "{{!", end: "}}", kind: model.MatchKindComment}},
+	}
+	styleBatch = commentStyle{
+		linePrefixes: []string{"REM ", "rem ", "::"},
+	}
+	stylePug = commentStyle{
+		linePrefixes: []string{"//", "//-"},
+	}
+	styleBash = commentStyle{
+		linePrefixes: []string{"#"},
+		stringDelims: []string{"\"", "'", "`"},
+	}
+)
+
+var languageStyleMap = map[string]commentStyle{
+	"c":               styleC,
+	"cpp":             styleC,
+	"objective-c":     styleC,
+	"objective-cpp":   styleC,
+	"go":              styleGo,
+	"java":            styleC,
+	"csharp":          styleC,
+	"scala":           styleC,
+	"kotlin":          styleC,
+	"swift":           styleC,
+	"groovy":          styleC,
+	"dart":            styleC,
+	"rust":            styleC,
+	"typescript":      styleJS,
+	"typescriptreact": styleJS,
+	"javascript":      styleJS,
+	"javascriptreact": styleJS,
+	"coffeescript":    styleJS,
+	"php":             styleJS,
+	"proto":           styleC,
+	"thrift":          styleC,
+	"hcl":             styleHCL,
+	"terraform":       styleHCL,
+	"cue":             styleHash,
+	"starlark":        stylePython,
+	"python":          stylePython,
+	"ruby":            styleRuby,
+	"perl":            styleHash,
+	"shell":           styleBash,
+	"fish":            styleHash,
+	"powershell":      stylePowershell,
+	"batch":           styleBatch,
+	"yaml":            styleHash,
+	"toml":            styleHash,
+	"ini":             styleIni,
+	"properties":      styleIni,
+	"dotenv":          styleHash,
+	"json":            styleHash,
+	"markdown":        styleHash,
+	"rst":             styleHash,
+	"asciidoc":        styleHash,
+	"latex":           styleHash,
+	"html":            styleHTML,
+	"vue":             styleHTML,
+	"svelte":          styleHTML,
+	"xml":             styleHTML,
+	"css":             styleCSS,
+	"scss":            styleCSS,
+	"sass":            styleCSS,
+	"less":            styleCSS,
+	"stylus":          styleCSS,
+	"sql":             styleSQL,
+	"make":            styleHash,
+	"ninja":           styleHash,
+	"dockerfile":      styleHash,
+	"jinja":           styleJinja,
+	"twig":            styleTwig,
+	"handlebars":      styleHandlebars,
+	"django":          styleJinja,
+	"liquid":          styleJinja,
+	"pug":             stylePug,
+	"haml":            styleHash,
+	"erb":             styleRuby,
+	"ejs":             styleJS,
+	"aspnet":          styleHTML,
+	"common-lisp":     styleLisp,
+	"scheme":          styleLisp,
+	"racket":          styleLisp,
+	"haskell":         styleHaskell,
+	"erlang":          styleHash,
+	"elixir":          styleHash,
+	"elm":             styleJS,
+	"ocaml":           styleHaskell,
+	"pascal":          styleHash,
+	"ada":             styleHash,
+	"verilog":         styleC,
+	"systemverilog":   styleC,
+	"cython":          stylePython,
+	"apex":            styleC,
+	"ahk":             styleHash,
+	"autoit":          styleHash,
+	"nim":             styleHash,
+	"zig":             styleC,
+	"smali":           styleHash,
+	"julia":           styleHash,
+	"rego":            styleHash,
+	"pip":             styleHash,
+	"gradle":          styleC,
+	"cmake":           styleHash,
+	"procfile":        styleHash,
+}
+
+func styleForLanguage(lang string) (commentStyle, bool) {
+	cs, ok := languageStyleMap[lang]
+	return cs, ok
+}

--- a/internal/engine/opts/opts_test.go
+++ b/internal/engine/opts/opts_test.go
@@ -82,19 +82,24 @@ func TestNormalizeAndValidate(t *testing.T) {
 	t.Parallel()
 
 	opts := engine.Options{
-		Type:         "TODO",
-		Mode:         "FIRST",
-		WithComment:  true,
-		WithMessage:  true,
-		TruncAll:     0,
-		TruncComment: 0,
-		TruncMessage: 0,
-		IgnoreWS:     true,
-		Jobs:         8,
-		RepoDir:      "",
-		Paths:        []string{" src ", ""},
-		Excludes:     []string{" vendor/** ", ""},
-		PathRegex:    []string{"^src/", ""},
+		Type:           "TODO",
+		Mode:           "FIRST",
+		DetectMode:     "PARSE",
+		WithComment:    true,
+		WithMessage:    true,
+		IncludeStrings: false,
+		TruncAll:       0,
+		TruncComment:   0,
+		TruncMessage:   0,
+		IgnoreWS:       true,
+		Jobs:           8,
+		RepoDir:        "",
+		Paths:          []string{" src ", ""},
+		Excludes:       []string{" vendor/** ", ""},
+		PathRegex:      []string{"^src/", ""},
+		DetectLangs:    []string{" go ", "Ts"},
+		Tags:           []string{" TODO ", ""},
+		MaxFileBytes:   4096,
 	}
 
 	if err := NormalizeAndValidate(&opts); err != nil {
@@ -106,11 +111,17 @@ func TestNormalizeAndValidate(t *testing.T) {
 	if opts.Mode != "first" {
 		t.Fatalf("mode not normalized: %q", opts.Mode)
 	}
+	if opts.DetectMode != "parse" {
+		t.Fatalf("detect mode not normalized: %q", opts.DetectMode)
+	}
 	if opts.TruncAll != 120 {
 		t.Fatalf("expected truncate default of 120 when both comment/message, got %d", opts.TruncAll)
 	}
 	if opts.RepoDir != "." {
 		t.Fatalf("repo dir should default to '.' when empty: %q", opts.RepoDir)
+	}
+	if opts.IncludeStrings {
+		t.Fatalf("include strings should remain false when disabled")
 	}
 	if len(opts.Paths) != 1 || opts.Paths[0] != "src" {
 		t.Fatalf("paths should be trimmed: %#v", opts.Paths)
@@ -123,6 +134,15 @@ func TestNormalizeAndValidate(t *testing.T) {
 	}
 	if len(opts.PathRegexCompiled) != 1 || opts.PathRegexCompiled[0].String() != "^src/" {
 		t.Fatalf("compiled regex should mirror trimmed pattern: %#v", opts.PathRegexCompiled)
+	}
+	if want := []string{"go", "typescript"}; !reflect.DeepEqual(opts.DetectLangs, want) {
+		t.Fatalf("detect langs should be canonicalized: %#v", opts.DetectLangs)
+	}
+	if len(opts.Tags) != 1 || opts.Tags[0] != "TODO" {
+		t.Fatalf("tags should be trimmed: %#v", opts.Tags)
+	}
+	if opts.MaxFileBytes != 4096 {
+		t.Fatalf("max file bytes should be preserved: %d", opts.MaxFileBytes)
 	}
 
 	bad := engine.Options{Type: "unknown", Mode: "last", Jobs: 1}
@@ -144,6 +164,24 @@ func TestNormalizeAndValidate(t *testing.T) {
 	if err := NormalizeAndValidate(&invalidRegex); err == nil {
 		t.Fatal("expected error for invalid path regex")
 	}
+
+	invalidDetect := engine.Options{Type: "todo", Mode: "last", Jobs: 1, DetectMode: "fast"}
+	if err := NormalizeAndValidate(&invalidDetect); err == nil {
+		t.Fatal("expected error for invalid detect mode")
+	}
+
+	negativeSize := engine.Options{Type: "todo", Mode: "last", Jobs: 1, MaxFileBytes: -1}
+	if err := NormalizeAndValidate(&negativeSize); err == nil {
+		t.Fatal("expected error for negative max_file_bytes")
+	}
+
+	alias := engine.Options{Type: "todo", Mode: "last", Jobs: 1, DetectLangs: []string{"js", "JS", "py"}}
+	if err := NormalizeAndValidate(&alias); err != nil {
+		t.Fatalf("unexpected error for alias detect_langs: %v", err)
+	}
+	if want := []string{"javascript", "python"}; !reflect.DeepEqual(alias.DetectLangs, want) {
+		t.Fatalf("expected canonical detect_langs, got %v", alias.DetectLangs)
+	}
 }
 
 func TestApplyWebQueryToOptions(t *testing.T) {
@@ -163,9 +201,11 @@ func TestApplyWebQueryToOptions(t *testing.T) {
 	q.Add("truncate", "80")
 	q.Add("truncate_comment", "10")
 	q.Add("truncate_comment", "20")
-	q.Add("truncate_message", "5,15")
+	q.Add("truncate_message", "5")
+	q.Add("truncate_message", "15")
 	q.Add("jobs", "2")
-	q.Add("jobs", "4,6")
+	q.Add("jobs", "4")
+	q.Add("jobs", "6")
 	q.Add("ignore_ws", "1")
 	q.Add("ignore_ws", "0")
 	q.Add("progress", "0")
@@ -180,6 +220,19 @@ func TestApplyWebQueryToOptions(t *testing.T) {
 	q.Add("path_regex", "\\.go$")
 	q.Add("exclude_typical", "0")
 	q.Add("exclude_typical", "1")
+	q.Add("detect", "parse")
+	q.Add("detect", "regex")
+	q.Add("detect_langs", "go,ts")
+	q.Add("detect_langs", "python")
+	q.Add("tags", "TODO")
+	q.Add("tags", "FIXME")
+	q.Add("include_strings", "true")
+	q.Add("include_strings", "false")
+	q.Add("comments_only", "true")
+	q.Add("max_file_bytes", "2048")
+	q.Add("max_file_bytes", "4096")
+	q.Add("no_prefilter", "0")
+	q.Add("no_prefilter", "1")
 
 	got, err := ApplyWebQueryToOptions(base, q)
 	if err != nil {
@@ -212,6 +265,24 @@ func TestApplyWebQueryToOptions(t *testing.T) {
 	if !got.Progress {
 		t.Fatal("expected progress to be true when last literal is truthy")
 	}
+	if got.DetectMode != "regex" {
+		t.Fatalf("expected detect override to apply, got %q", got.DetectMode)
+	}
+	if want := []string{"go", "ts", "python"}; !reflect.DeepEqual(got.DetectLangs, want) {
+		t.Fatalf("detect_langs mismatch: got=%v want=%v", got.DetectLangs, want)
+	}
+	if want := []string{"TODO", "FIXME"}; !reflect.DeepEqual(got.Tags, want) {
+		t.Fatalf("tags mismatch: got=%v want=%v", got.Tags, want)
+	}
+	if got.IncludeStrings {
+		t.Fatalf("include_strings should be false after comments_only=true")
+	}
+	if got.MaxFileBytes != 4096 {
+		t.Fatalf("expected last max_file_bytes literal, got %d", got.MaxFileBytes)
+	}
+	if !got.NoPrefilter {
+		t.Fatal("expected no_prefilter to be true")
+	}
 	if got.AuthorRegex != "Bob" {
 		t.Fatalf("expected author to use last raw value, got %q", got.AuthorRegex)
 	}
@@ -236,6 +307,35 @@ func TestApplyWebQueryToOptions(t *testing.T) {
 	q.Set("jobs", "0")
 	if _, err := ApplyWebQueryToOptions(base, q); err == nil {
 		t.Fatal("expected error for jobs below range")
+	}
+}
+
+func TestApplyWebQueryIncludeStringsPriority(t *testing.T) {
+	t.Parallel()
+
+	base := Defaults("/repo")
+	q := url.Values{}
+	q.Add("include_strings", "false")
+	q.Add("comments_only", "false")
+	q.Add("no_strings", "true")
+
+	got, err := ApplyWebQueryToOptions(base, q)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.IncludeStrings {
+		t.Fatalf("expected include_strings to be false after no_strings=true, got true")
+	}
+
+	q = url.Values{}
+	q.Add("no_strings", "true")
+	q.Add("include_strings", "true")
+	got, err = ApplyWebQueryToOptions(base, q)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.IncludeStrings {
+		t.Fatalf("expected no_strings to override include_strings in query inputs")
 	}
 }
 

--- a/internal/engine/types.go
+++ b/internal/engine/types.go
@@ -4,23 +4,29 @@ import (
 	"regexp"
 	"time"
 
+	"github.com/phyten/todox/internal/model"
 	"github.com/phyten/todox/internal/progress"
 )
 
 // Item は 1 件の TODO/FIXME を表す
 type Item struct {
-	Kind    string           `json:"kind"` // TODO | FIXME | TODO|FIXME
-	Author  string           `json:"author"`
-	Email   string           `json:"email"`
-	Date    string           `json:"date"`     // author date (iso-strict-local)
-	AgeDays int              `json:"age_days"` // author date からの経過日数
-	Commit  string           `json:"commit"`   // full SHA
-	File    string           `json:"file"`
-	Line    int              `json:"line"`
-	Comment string           `json:"comment,omitempty"` // TODO/FIXME からの行
-	Message string           `json:"message,omitempty"` // commit subject (1行目)
-	URL     string           `json:"url,omitempty"`     // コミット行への恒久リンク
-	PRs     []PullRequestRef `json:"prs,omitempty"`
+	Kind      string           `json:"kind"`
+	Tag       string           `json:"tag,omitempty"`
+	Lang      string           `json:"lang,omitempty"`
+	MatchKind string           `json:"match_kind,omitempty"`
+	Text      string           `json:"text,omitempty"`
+	Span      model.Span       `json:"span"`
+	Author    string           `json:"author"`
+	Email     string           `json:"email"`
+	Date      string           `json:"date"`
+	AgeDays   int              `json:"age_days"`
+	Commit    string           `json:"commit"`
+	File      string           `json:"file"`
+	Line      int              `json:"line"`
+	Comment   string           `json:"comment,omitempty"`
+	Message   string           `json:"message,omitempty"`
+	URL       string           `json:"url,omitempty"`
+	PRs       []PullRequestRef `json:"prs,omitempty"`
 }
 
 // PullRequestRef はコミットに紐づく PR の参照情報を表す
@@ -44,9 +50,12 @@ type ItemError struct {
 type Options struct {
 	Type              string // todo|fixme|both
 	Mode              string // last|first
+	DetectMode        string
 	AuthorRegex       string
 	WithComment       bool
 	WithMessage       bool
+	IncludeStrings    bool
+	Tags              []string
 	TruncAll          int
 	TruncComment      int
 	TruncMessage      int
@@ -55,11 +64,14 @@ type Options struct {
 	RepoDir           string
 	Progress          bool
 	Now               time.Time
+	DetectLangs       []string
 	Paths             []string
 	Excludes          []string
 	PathRegex         []string
 	PathRegexCompiled []*regexp.Regexp
+	MaxFileBytes      int
 	ExcludeTypical    bool
+	NoPrefilter       bool
 	ProgressObserver  progress.Observer `json:"-"`
 }
 

--- a/internal/model/match.go
+++ b/internal/model/match.go
@@ -1,0 +1,31 @@
+package model
+
+// MatchKind 表示検出対象の種別（コメント／文字列など）。
+type MatchKind string
+
+const (
+	MatchKindUnknown MatchKind = "unknown"
+	MatchKindComment MatchKind = "comment"
+	MatchKindString  MatchKind = "string"
+	MatchKindHeredoc MatchKind = "heredoc"
+)
+
+// Span は 1 件の検出範囲を行・桁・バイトオフセットで表します。
+type Span struct {
+	StartLine int
+	StartCol  int
+	EndLine   int
+	EndCol    int
+	ByteStart int
+	ByteEnd   int
+}
+
+// Match は構文解析またはフォールバック検出による 1 件の TODO/FIXME を表します。
+type Match struct {
+	File string
+	Lang string
+	Kind MatchKind
+	Tag  string
+	Text string
+	Span Span
+}


### PR DESCRIPTION
## Summary
- treat Go raw string literals as block captures so multiline TODO markers in raw strings are found and covered by tests
- document that Web API parameters follow the config/env precedence for include_strings toggles

## Testing
- go test ./...
- make build
- make lint

------
https://chatgpt.com/codex/tasks/task_e_68e7df622c0c8320b6039ff6b4e526e0