### PR TITLE
Revamp web UI layout for CSP-safe controls

### DIFF
--- a/internal/web/app.go
+++ b/internal/web/app.go
@@ -7,7 +7,10 @@ import (
 	"sync"
 )
 
-const stylesPath = "/assets/styles.css"
+const (
+	stylesPath = "/assets/styles.css"
+	scriptPath = "/assets/ui.js"
+)
 
 var (
 	//go:embed templates/index.html
@@ -17,16 +20,21 @@ var (
 
 	//go:embed assets/styles.css
 	stylesCSS string
+
+	//go:embed assets/ui.js
+	scriptJS string
 )
 
 type indexData struct {
 	StylesPath string
+	ScriptPath string
 }
 
 // Register attaches handlers for the web UI assets to the provided mux.
 func Register(mux *http.ServeMux) {
 	mux.HandleFunc("/", indexHandler)
 	mux.HandleFunc(stylesPath, stylesHandler)
+	mux.HandleFunc(scriptPath, scriptHandler)
 }
 
 func indexHandler(w http.ResponseWriter, r *http.Request) {
@@ -35,8 +43,8 @@ func indexHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("X-Content-Type-Options", "nosniff")
 	w.Header().Set("Referrer-Policy", "no-referrer")
 	w.Header().Set("X-Frame-Options", "DENY")
-	w.Header().Set("Content-Security-Policy", "default-src 'none'; style-src 'self'; script-src 'unsafe-inline'; img-src 'self'; connect-src 'self'; form-action 'self'; base-uri 'none'")
-	if err := tmpl.Execute(w, indexData{StylesPath: stylesPath}); err != nil {
+	w.Header().Set("Content-Security-Policy", "default-src 'none'; style-src 'self'; script-src 'self'; img-src 'self'; connect-src 'self'; form-action 'self'; base-uri 'none'")
+	if err := tmpl.Execute(w, indexData{StylesPath: stylesPath, ScriptPath: scriptPath}); err != nil {
 		http.Error(w, "template rendering failed", http.StatusInternalServerError)
 	}
 }
@@ -45,6 +53,12 @@ func stylesHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "text/css; charset=utf-8")
 	w.Header().Set("Cache-Control", "public, max-age=86400")
 	_, _ = w.Write([]byte(stylesCSS))
+}
+
+func scriptHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/javascript; charset=utf-8")
+	w.Header().Set("Cache-Control", "public, max-age=86400")
+	_, _ = w.Write([]byte(scriptJS))
 }
 
 func loadTemplate() *template.Template {

--- a/internal/web/assets/styles.css
+++ b/internal/web/assets/styles.css
@@ -1,41 +1,45 @@
 :root {
-  color-scheme: light dark;
-  --page-bg: #ffffff;
-  --page-fg: #111827;
-  --surface: #f9fafb;
-  --border: #d1d5db;
+  color-scheme: dark light;
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-5: 20px;
+  --space-6: 24px;
+  --space-8: 32px;
+  --radius-1: 8px;
+  --radius-2: 12px;
+  --bg: #0f1216;
+  --surface-1: #161a20;
+  --surface-2: #1b212a;
+  --surface-3: #242c37;
+  --text-1: #e6e9ef;
+  --text-2: #aab2bf;
+  --primary: #7aa2f7;
+  --primary-fg: #0b1020;
+  --accent: #7dcfff;
+  --danger: #f7768e;
+  --success: #9ece6a;
   --muted: #6b7280;
-  --input-bg: #ffffff;
-  --input-border: #cbd5f5;
-  --link: #1d4ed8;
-  --error-bg: #fef2f2;
-  --error-border: #fecaca;
-  --error-fg: #7f1d1d;
-  --badge-ring-opacity: 0.35;
-  --badge-todo-bg: #f59e0b;
-  --badge-todo-fg: #111827;
-  --badge-fixme-bg: #dc2626;
-  --badge-fixme-fg: #ffffff;
+  --border: rgba(255, 255, 255, 0.08);
+  --border-strong: rgba(255, 255, 255, 0.18);
+  --shadow-1: 0 6px 16px rgba(0, 0, 0, 0.35);
+  --shadow-2: 0 10px 24px rgba(0, 0, 0, 0.4);
+  --font-family: system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, "Apple Color Emoji", "Segoe UI Emoji";
 }
 
-@media (prefers-color-scheme: dark) {
+@media (prefers-color-scheme: light) {
   :root {
-    --page-bg: #0f172a;
-    --page-fg: #e2e8f0;
-    --surface: #1e293b;
-    --border: #334155;
-    --muted: #94a3b8;
-    --input-bg: #1e293b;
-    --input-border: #475569;
-    --link: #93c5fd;
-    --error-bg: #471515;
-    --error-border: #b91c1c;
-    --error-fg: #fecaca;
-    --badge-ring-opacity: 0.55;
-    --badge-todo-bg: #92400e;
-    --badge-todo-fg: #fff7ed;
-    --badge-fixme-bg: #b91c1c;
-    --badge-fixme-fg: #ffffff;
+    --bg: #f5f7fa;
+    --surface-1: #ffffff;
+    --surface-2: #e6ebf2;
+    --surface-3: #d8dfe9;
+    --text-1: #1f2937;
+    --text-2: #4b5563;
+    --border: rgba(17, 24, 39, 0.08);
+    --border-strong: rgba(17, 24, 39, 0.18);
+    --shadow-1: 0 6px 16px rgba(15, 23, 42, 0.12);
+    --shadow-2: 0 10px 24px rgba(15, 23, 42, 0.16);
   }
 }
 
@@ -43,279 +47,664 @@
   box-sizing: border-box;
 }
 
+html,
 body {
-  margin: 20px;
-  font: 14px/1.45 system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-  background: var(--page-bg);
-  color: var(--page-fg);
-}
-
-h2 {
-  margin-top: 0;
-}
-
-label {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  margin-right: 12px;
-  margin-bottom: 8px;
-  color: inherit;
-}
-
-select,
-input[type="text"],
-input[type="number"] {
-  padding: 4px 6px;
-  border-radius: 4px;
-  border: 1px solid var(--input-border);
-  background: var(--input-bg);
-  color: inherit;
-  min-height: 28px;
-}
-
-input[type="text"] {
-  width: 240px;
-}
-
-button {
-  border: 1px solid var(--border);
-  border-radius: 4px;
-  padding: 6px 12px;
-  background: var(--surface);
-  color: inherit;
-  cursor: pointer;
-}
-
-button:hover,
-button:focus {
-  border-color: var(--link);
-  outline: none;
-}
-
-.small {
-  color: var(--muted);
-}
-
-table {
-  border-collapse: collapse;
-  width: 100%;
-  background: var(--page-bg);
-}
-
-th,
-td {
-  border: 1px solid var(--border);
-  padding: 6px 8px;
-  vertical-align: top;
-}
-
-th {
-  text-align: left;
-}
-
-.sort-btn {
-  background: transparent;
-  border: 0;
-  color: inherit;
-  cursor: pointer;
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
+  margin: 0;
   padding: 0;
+  background: var(--bg);
+  color: var(--text-1);
+  font-family: var(--font-family);
+  line-height: 1.45;
+}
+
+body {
+  min-height: 100vh;
+}
+
+.is-hidden {
+  display: none !important;
+}
+
+button,
+input,
+textarea,
+select {
   font: inherit;
+  color: inherit;
 }
 
-th .sort-btn {
-  width: 100%;
-  justify-content: flex-start;
+input,
+textarea,
+select {
+  background: var(--surface-1);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-1);
+  padding: 0 var(--space-3);
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
 }
 
-.sort-btn:hover {
-  color: var(--link);
+input:focus,
+textarea:focus,
+select:focus,
+button:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px rgba(125, 207, 255, 0.35);
 }
 
-.sort-btn:focus-visible {
-  outline: 2px solid var(--link);
-  outline-offset: 2px;
+textarea {
+  padding-block: var(--space-2);
+  resize: vertical;
 }
 
-.sort-btn::after {
-  content: '';
-  font-size: 11px;
-  line-height: 1;
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-1);
+  min-height: 36px;
+  padding-inline: var(--space-4);
+  border-radius: var(--radius-1);
+  border: 1px solid var(--border);
+  background: var(--surface-1);
+  color: var(--text-1);
+  cursor: pointer;
+  transition: background 0.15s ease, border-color 0.15s ease, transform 0.15s ease;
 }
 
-.sort-btn.asc::after {
-  content: '▲';
+.btn:hover {
+  border-color: var(--accent);
 }
 
-.sort-btn.desc::after {
-  content: '▼';
+.btn:active {
+  transform: translateY(1px);
 }
 
-thead {
+.btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.btn.copied::after {
+  content: '✓';
+  margin-inline-start: var(--space-2);
+  font-size: 0.85rem;
+  color: var(--accent);
+}
+
+.btn-primary {
+  background: var(--primary);
+  color: var(--primary-fg);
+  border: none;
+  font-weight: 600;
+}
+
+.btn-secondary {
+  background: var(--surface-2);
+  border-color: var(--border-strong);
+}
+
+.btn-icon {
+  inline-size: 36px;
+  block-size: 36px;
+  padding: 0;
+  border-radius: 999px;
+}
+
+.btn-ghost {
+  border-style: dashed;
+  background: transparent;
+  color: var(--text-1);
+}
+
+.chip {
+  border-radius: 999px;
+  padding-inline: var(--space-3);
+  padding-block: var(--space-1);
+  font-size: 0.9rem;
+  border: 1px solid var(--border);
+  background: var(--surface-2);
+  color: var(--text-1);
+  cursor: pointer;
+}
+
+.chip:hover,
+.chip:focus-visible {
+  border-color: var(--accent);
+}
+
+.app-shell {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+.toolbar {
   position: sticky;
   top: 0;
-  background: var(--surface);
-  color: inherit;
-}
-
-code {
-  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace;
-}
-
-.errors {
-  background: var(--error-bg);
-  border: 1px solid var(--error-border);
-  color: var(--error-fg);
-  padding: 8px;
-  margin: 12px 0;
-  border-radius: 6px;
-}
-
-.error-banner {
-  display: none;
-  align-items: center;
-  justify-content: space-between;
-  background: var(--error-bg);
-  border: 1px solid var(--error-border);
-  color: var(--error-fg);
-  padding: 8px 12px;
-  margin: 12px 0;
-  border-radius: 6px;
-}
-
-.error-banner button {
-  background: transparent;
-  border: 0;
-  font-size: 18px;
-  line-height: 1;
-  cursor: pointer;
-  color: inherit;
-  padding: 0;
-  margin-left: 12px;
-}
-
-.badge {
-  --badge-bg: var(--surface);
-  --badge-fg: currentColor;
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  padding: 2px 6px;
-  border-radius: 6px;
-  font-weight: 600;
-  line-height: 1.1;
-  background: var(--badge-bg);
-  color: var(--badge-fg);
-  border: 1px solid rgba(0, 0, 0, var(--badge-ring-opacity));
-}
-
-.badge[data-type="TODO"] {
-  --badge-bg: var(--badge-todo-bg);
-  --badge-fg: var(--badge-todo-fg);
-}
-
-.badge[data-type="FIXME"] {
-  --badge-bg: var(--badge-fixme-bg);
-  --badge-fg: var(--badge-fixme-fg);
-}
-
-a.link-icon {
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  text-decoration: none;
-  font-size: 16px;
-}
-
-a.link-icon span {
-  line-height: 1;
-}
-
-@media (prefers-color-scheme: dark) {
-  .badge {
-    border-color: rgba(255, 255, 255, var(--badge-ring-opacity));
-  }
-}
-
-.progress-wrap {
-  margin: 12px 0 16px;
-  padding: 12px;
-  background: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: 8px;
-}
-
-.progress-header {
+  z-index: 50;
   display: flex;
-  gap: 12px;
   align-items: center;
-  justify-content: space-between;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-4);
+  backdrop-filter: blur(6px);
+  background: color-mix(in srgb, var(--bg) 85%, transparent);
+  border-bottom: 1px solid var(--border);
 }
 
-.linklike {
-  background: none;
-  border: none;
-  color: var(--link);
-  cursor: pointer;
-  text-decoration: underline;
-  padding: 0;
-}
-
-.stepper {
-  display: flex;
-  gap: 10px;
-  list-style: none;
-  padding: 6px 0;
+.app-title {
+  font-size: 1.25rem;
   margin: 0;
-  font-size: 12px;
 }
 
-.stepper li {
-  padding: 2px 8px;
-  border-radius: 999px;
-  border: 1px solid var(--border);
-}
-
-.stepper li.current {
-  font-weight: 600;
-}
-
-.stepper li.done {
-  background: var(--surface);
-  opacity: 0.75;
-}
-
-.progressbar {
-  width: 100%;
-  height: 10px;
-  background: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: 999px;
-  overflow: hidden;
-  margin: 4px 0 8px;
-}
-
-#progressbar-inner {
-  height: 100%;
-  width: 0%;
-  background: linear-gradient(90deg, #93c5fd, #60a5fa);
-}
-
-@media (prefers-color-scheme: dark) {
-  #progressbar-inner {
-    background: linear-gradient(90deg, #1d4ed8, #3b82f6);
-  }
-}
-
-.progress-footer {
+.toolbar-presets {
   display: flex;
-  gap: 16px;
   flex-wrap: wrap;
+  gap: var(--space-2);
+  margin-inline-start: var(--space-3);
+}
+
+.popover {
+  position: relative;
+  margin-inline-start: auto;
+}
+
+.popover > summary {
+  list-style: none;
+}
+
+.popover[open] > summary::marker,
+.popover > summary::marker {
+  display: none;
+}
+
+.popover__content {
+  position: absolute;
+  inset-block-start: calc(100% + var(--space-2));
+  inset-inline-end: 0;
+  inline-size: min(56ch, 90vw);
+  max-height: 50vh;
+  overflow: auto;
+  padding: var(--space-4);
+  border-radius: var(--radius-2);
+  border: 1px solid var(--border-strong);
+  background: var(--surface-1);
+  box-shadow: var(--shadow-1);
+  display: grid;
+  gap: var(--space-3);
+  animation: fadeIn 120ms ease-out;
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; transform: translateY(-4px); }
+  to { opacity: 1; transform: none; }
+}
+
+.code {
+  font-family: "SFMono-Regular", Menlo, Consolas, "Liberation Mono", monospace;
+  white-space: pre-wrap;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-1);
+  padding: var(--space-3);
+  background: var(--surface-1);
 }
 
 .muted {
   color: var(--muted);
+  font-size: 0.85rem;
+}
+
+.layout {
+  display: grid;
+  grid-template-columns: minmax(320px, 420px) 1fr;
+  gap: var(--space-6);
+  padding: var(--space-6);
+}
+
+.layout.is-single {
+  grid-template-columns: 1fr;
+}
+
+.filters {
+  position: sticky;
+  top: calc(64px + var(--space-3));
+  align-self: start;
+}
+
+.filters.is-collapsed {
+  display: none;
+}
+
+.panel {
+  background: var(--surface-1);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-2);
+  padding: var(--space-5);
+  box-shadow: var(--shadow-1);
+}
+
+.section {
+  border: none;
+  padding: 0;
+  margin: 0 0 var(--space-6) 0;
+}
+
+.section:last-of-type {
+  margin-bottom: 0;
+}
+
+.section > legend {
+  font-weight: 600;
+  font-size: 0.95rem;
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  margin-bottom: var(--space-3);
+}
+
+.help-toggle {
+  inline-size: 24px;
+  block-size: 24px;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  background: transparent;
+  color: var(--text-2);
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.help-text {
+  margin-bottom: var(--space-3);
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.field-grid {
+  display: grid;
+  gap: var(--space-4);
+}
+
+.field-grid label {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  font-size: 0.9rem;
+}
+
+.checkbox,
+.select {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.checkbox input {
+  inline-size: 18px;
+  block-size: 18px;
+}
+
+.checkbox-grid {
+  display: grid;
+  gap: var(--space-2);
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.subsection {
+  display: grid;
+  gap: var(--space-3);
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  padding: var(--space-3);
+  background: var(--surface-2);
+  border-radius: var(--radius-1);
+  border: 1px dashed var(--border);
+}
+
+.note {
+  color: var(--muted);
+  font-size: 0.85rem;
+  margin: 0;
+}
+
+.control {
+  display: grid;
+  gap: var(--space-2);
+}
+
+.control-label {
+  font-weight: 600;
+  color: var(--text-2);
+}
+
+.segmented {
+  display: inline-grid;
+  grid-auto-flow: column;
+  gap: 0;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.segmented input {
+  position: absolute;
+  pointer-events: none;
+  opacity: 0;
+}
+
+.segmented label {
+  padding: var(--space-2) var(--space-3);
+  cursor: pointer;
+  background: var(--surface-1);
+  color: var(--text-2);
+  font-size: 0.9rem;
+}
+
+.segmented input:checked + label {
+  background: var(--primary);
+  color: var(--primary-fg);
+}
+
+.results {
+  display: grid;
+  gap: var(--space-4);
+}
+
+.banner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--space-3) var(--space-4);
+  border-radius: var(--radius-1);
+  background: rgba(247, 118, 142, 0.12);
+  border: 1px solid rgba(247, 118, 142, 0.4);
+  color: var(--danger);
+  box-shadow: var(--shadow-1);
+}
+
+.progress-panel {
+  display: grid;
+  gap: var(--space-3);
+  padding: var(--space-4);
+  border-radius: var(--radius-2);
+  border: 1px solid var(--border);
+  background: var(--surface-1);
+  box-shadow: var(--shadow-1);
+}
+
+.progress-head {
+  display: grid;
+  gap: var(--space-2);
+}
+
+progress {
+  width: 100%;
+  height: 12px;
+}
+
+progress[data-indeterminate="true"] {
+  position: relative;
+  background-color: var(--surface-2);
+}
+
+progress[data-indeterminate="true"]::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(90deg, transparent 0%, rgba(125, 207, 255, 0.4) 50%, transparent 100%);
+  animation: shimmer 1.2s infinite;
+}
+
+@keyframes shimmer {
+  from { transform: translateX(-100%); }
+  to { transform: translateX(100%); }
+}
+
+.progress-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-3);
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.progress-stages {
+  display: flex;
+  gap: var(--space-2);
+}
+
+.stage {
+  padding: var(--space-1) var(--space-2);
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.stage[data-active="true"] {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.stage[data-status="done"] {
+  border-color: var(--accent);
+  color: var(--accent);
+  opacity: 0.7;
+}
+
+.progress-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  font-size: 0.85rem;
+}
+
+.results-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+}
+
+.results-actions {
+  display: flex;
+  gap: var(--space-2);
+}
+
+.table-shell {
+  border-radius: var(--radius-2);
+  border: 1px solid var(--border);
+  overflow: hidden;
+  background: var(--surface-1);
+  box-shadow: var(--shadow-1);
+}
+
+.table-shell table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 640px;
+}
+
+.table-shell thead {
+  background: var(--surface-2);
+  position: sticky;
+  top: 0;
+  z-index: 1;
+}
+
+.table-shell th,
+.table-shell td {
+  padding: var(--space-3);
+  border-bottom: 1px solid var(--border);
+  text-align: left;
+  font-size: 0.9rem;
+}
+
+.table-shell tbody tr:nth-child(even) {
+  background: color-mix(in srgb, var(--surface-1) 80%, transparent);
+}
+
+.sort-btn {
+  background: none;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  font-weight: 600;
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+}
+
+.sort-btn::after {
+  content: '';
+  inline-size: 0.6em;
+  block-size: 0.6em;
+  border-right: 2px solid currentColor;
+  border-bottom: 2px solid currentColor;
+  transform: rotate(45deg);
+  opacity: 0.3;
+}
+
+.sort-btn.asc::after {
+  transform: rotate(-135deg);
+  opacity: 1;
+}
+
+.sort-btn.desc::after {
+  transform: rotate(45deg);
+  opacity: 1;
+}
+
+.badge {
+  display: inline-block;
+  padding: 2px 6px;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.badge[data-type="TODO"] {
+  background: rgba(125, 207, 255, 0.15);
+  color: var(--accent);
+}
+
+.badge[data-type="FIXME"] {
+  background: rgba(247, 118, 142, 0.15);
+  color: var(--danger);
+}
+
+.badge[data-type="OTHER"] {
+  background: rgba(154, 205, 50, 0.15);
+  color: var(--success);
+}
+
+.link-icon {
+  color: var(--accent);
+  text-decoration: none;
+}
+
+.link-icon:hover,
+.link-icon:focus-visible {
+  text-decoration: underline;
+}
+
+.pr-list {
+  display: grid;
+  gap: var(--space-2);
+}
+
+.actionbar {
+  position: sticky;
+  bottom: 0;
+  z-index: 40;
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-4);
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--space-3) var(--space-4);
+  border-top: 1px solid var(--border);
+  background: color-mix(in srgb, var(--bg) 85%, transparent);
+  backdrop-filter: blur(6px);
+}
+
+.action-buttons {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.share-fields {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: var(--space-3);
+  align-items: start;
+}
+
+.share-field {
+  display: grid;
+  gap: var(--space-2);
+  position: relative;
+}
+
+.share-field textarea,
+.share-field input {
+  padding-right: 40px;
+  min-height: 60px;
+}
+
+.share-field input {
+  min-height: 36px;
+}
+
+.share-field .btn-icon {
+  position: absolute;
+  inset-inline-end: var(--space-2);
+  inset-block-start: var(--space-2);
+}
+
+@media (max-width: 1200px) {
+  .layout {
+    grid-template-columns: 1fr;
+  }
+
+  .filters {
+    position: static;
+  }
+
+  .actionbar {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .action-buttons {
+    justify-content: center;
+  }
+}
+
+@media (max-width: 720px) {
+  .toolbar {
+    flex-wrap: wrap;
+  }
+
+  .toolbar-presets {
+    order: 3;
+    width: 100%;
+  }
+
+  .popover {
+    width: 100%;
+    order: 4;
+  }
+
+  .popover__content {
+    position: static;
+    box-shadow: var(--shadow-1);
+  }
+
+  .share-field .btn-icon {
+    inset-inline-end: var(--space-2);
+    inset-block-start: auto;
+    inset-block-end: var(--space-2);
+  }
 }

--- a/internal/web/assets/ui.js
+++ b/internal/web/assets/ui.js
@@ -1,0 +1,1677 @@
+(() => {
+  'use strict';
+
+  const form = document.getElementById('opts');
+  if (!form) {
+    return;
+  }
+
+  const layoutRoot = document.querySelector('.layout');
+  const filtersShell = document.querySelector('.filters');
+  const filterPanel = document.getElementById('filter-panel');
+  const collapseBtn = document.getElementById('collapseFilters');
+  const presetWrap = document.getElementById('preset-chips');
+  const errorBanner = document.getElementById('error-banner');
+  const errorMessage = document.getElementById('error-message');
+  const errorClose = document.getElementById('error-close');
+  const progressWrap = document.getElementById('progress');
+  const progressStage = document.getElementById('progress-stage');
+  const progressStats = document.getElementById('progress-stats');
+  const progressETA = document.getElementById('progress-eta');
+  const progressRate = document.getElementById('progress-rate');
+  const progressElapsed = document.getElementById('progress-elapsed');
+  const progressMeter = document.getElementById('progress-meter');
+  const progressCancel = document.getElementById('progress-cancel');
+  const stScan = document.getElementById('st-scan');
+  const stAttr = document.getElementById('st-attr');
+  const stPr = document.getElementById('st-pr');
+  const resultTable = document.getElementById('result-table');
+  const resultCount = document.getElementById('result-count');
+  const resultErrors = document.getElementById('result-errors');
+  const exportJSONBtn = document.getElementById('export-json');
+  const exportTSVBtn = document.getElementById('export-tsv');
+  const cliOutput = document.getElementById('cli-command');
+  const cliPreview = document.getElementById('cli-preview');
+  const cliHelp = document.getElementById('cli-help');
+  const shareURLEl = document.getElementById('share-url');
+  const cancelBtn = document.getElementById('cancel-scan');
+  const resetBtn = document.getElementById('reset-form');
+  const fieldAutoNote = document.getElementById('field-auto-note');
+  const prOptions = document.getElementById('pr-options');
+
+  const LOCAL_STORAGE_KEY = 'todox:lastParams';
+
+  let es = null;
+  let fetchAbort = null;
+  let latestResult = null;
+  let tableRows = [];
+  let sortKey = null;
+  let sortDesc = false;
+  let lastSnap = null;
+  let rafId = 0;
+
+  function showError(message) {
+    if (!errorBanner || !errorMessage) {
+      return;
+    }
+    errorMessage.textContent = message;
+    errorBanner.classList.remove('is-hidden');
+    errorBanner.removeAttribute('hidden');
+  }
+
+  function hideError() {
+    if (!errorBanner || !errorMessage) {
+      return;
+    }
+    errorBanner.classList.add('is-hidden');
+    errorBanner.setAttribute('hidden', '');
+    errorMessage.textContent = '';
+  }
+
+  if (errorClose) {
+    errorClose.addEventListener('click', (ev) => {
+      ev.preventDefault();
+      hideError();
+    });
+  }
+
+  function setPanelVisibility(panelEl, expanded) {
+    if (collapseBtn) {
+      collapseBtn.setAttribute('aria-expanded', String(expanded));
+      collapseBtn.setAttribute('aria-label', expanded ? 'フィルターを隠す' : 'フィルターを表示する');
+    }
+    if (filtersShell instanceof HTMLElement) {
+      filtersShell.classList.toggle('is-collapsed', !expanded);
+    }
+    if (layoutRoot instanceof HTMLElement) {
+      layoutRoot.classList.toggle('is-single', !expanded);
+    }
+    if (!(panelEl instanceof HTMLElement)) {
+      return;
+    }
+    if (expanded) {
+      panelEl.classList.remove('is-hidden');
+      panelEl.removeAttribute('hidden');
+    } else {
+      panelEl.classList.add('is-hidden');
+      panelEl.setAttribute('hidden', '');
+    }
+  }
+
+  function togglePanelFromTrigger(trigger) {
+    if (!trigger) {
+      return;
+    }
+    const selector = trigger.getAttribute('data-toggle');
+    if (!selector) {
+      return;
+    }
+    const target = document.querySelector(selector);
+    if (!(target instanceof HTMLElement)) {
+      return;
+    }
+    const expanded = trigger.getAttribute('aria-expanded') === 'true';
+    const next = !expanded;
+    trigger.setAttribute('aria-expanded', String(next));
+    if (trigger === collapseBtn) {
+      setPanelVisibility(target, next);
+    } else {
+      if (next) {
+        target.classList.remove('is-hidden');
+        target.removeAttribute('hidden');
+      } else {
+        target.classList.add('is-hidden');
+        target.setAttribute('hidden', '');
+      }
+    }
+  }
+
+  document.addEventListener('click', (ev) => {
+    const target = ev.target instanceof HTMLElement ? ev.target.closest('[data-toggle]') : null;
+    if (!(target instanceof HTMLElement)) {
+      return;
+    }
+    ev.preventDefault();
+    togglePanelFromTrigger(target);
+  });
+
+  if (collapseBtn && filterPanel) {
+    collapseBtn.addEventListener('keydown', (ev) => {
+      if (ev.key === 'Enter' || ev.key === ' ') {
+        ev.preventDefault();
+        togglePanelFromTrigger(collapseBtn);
+      }
+    });
+  }
+
+  document.addEventListener('keydown', (ev) => {
+    if (ev.key !== 'Escape') {
+      return;
+    }
+    if (!collapseBtn || !filterPanel) {
+      return;
+    }
+    const expanded = collapseBtn.getAttribute('aria-expanded') === 'true';
+    if (!expanded) {
+      return;
+    }
+    const activeElement = document.activeElement;
+    if (filterPanel.contains(activeElement)) {
+      setPanelVisibility(filterPanel, false);
+      collapseBtn.focus();
+    }
+  });
+
+  const desktopMedia = window.matchMedia('(min-width: 1025px)');
+  const handleDesktopChange = (event) => {
+    const shouldOpen = !!event.matches;
+    setPanelVisibility(filterPanel, shouldOpen);
+  };
+  if (typeof desktopMedia.addEventListener === 'function') {
+    desktopMedia.addEventListener('change', handleDesktopChange);
+  } else if (typeof desktopMedia.addListener === 'function') {
+    desktopMedia.addListener(handleDesktopChange);
+  }
+  handleDesktopChange(desktopMedia);
+
+  const helpButtons = form.querySelectorAll('.help-toggle');
+  helpButtons.forEach((btn) => {
+    btn.addEventListener('click', () => {
+      const expanded = btn.getAttribute('aria-expanded') === 'true';
+      const helpText = btn.parentElement ? btn.parentElement.nextElementSibling : null;
+      if (helpText && helpText.classList.contains('help-text')) {
+        if (expanded) {
+          helpText.hidden = true;
+          btn.setAttribute('aria-expanded', 'false');
+        } else {
+          helpText.hidden = false;
+          btn.setAttribute('aria-expanded', 'true');
+        }
+      }
+    });
+  });
+
+  function escText(value) {
+    return String(value ?? '')
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;');
+  }
+
+  function escAttr(value) {
+    return String(value ?? '')
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  }
+
+  function normalizePRTooltip(body) {
+    const collapsed = String(body ?? '')
+      .replace(/\r?\n/g, ' ')
+      .replace(/\\[rn]/g, ' ')
+      .replace(/\s+/g, ' ')
+      .trim();
+    if (!collapsed) {
+      return '';
+    }
+    return collapsed.length > 280 ? `${collapsed.slice(0, 279)}…` : collapsed;
+  }
+
+  function cssEscape(value) {
+    if (typeof CSS !== 'undefined' && typeof CSS.escape === 'function') {
+      return CSS.escape(String(value));
+    }
+    return String(value).replace(/[^a-zA-Z0-9_\-]/g, (ch) => {
+      const hex = ch.charCodeAt(0).toString(16);
+      return `\\${hex} `;
+    });
+  }
+
+  function renderBadge(kind) {
+    const raw = String(kind ?? '');
+    if (!raw) {
+      return '';
+    }
+    const upper = raw.toUpperCase();
+    let dataType = 'OTHER';
+    if (upper === 'TODO' || upper === 'FIXME') {
+      dataType = upper;
+    }
+    return `<span class="badge" data-type="${dataType}">${escText(upper)}</span>`;
+  }
+
+  function buildHeaderMeta(info) {
+    const meta = [
+      { key: 'kind', label: 'TYPE' },
+      { key: 'author', label: 'AUTHOR' },
+      { key: 'email', label: 'EMAIL' },
+      { key: 'date', label: 'DATE' },
+    ];
+    if (info && info.has_age) {
+      meta.push({ key: 'age_days', label: 'AGE' });
+    }
+    meta.push({ key: 'commit', label: 'COMMIT' });
+    meta.push({ key: 'location', label: 'LOCATION' });
+    if (info && info.has_url) {
+      meta.push({ key: 'url', label: 'URL' });
+    }
+    if (info && info.has_prs) {
+      meta.push({ key: 'prs', label: 'PRS' });
+    }
+    if (info && info.has_comment) {
+      meta.push({ key: 'comment', label: 'COMMENT' });
+    }
+    if (info && info.has_message) {
+      meta.push({ key: 'message', label: 'MESSAGE' });
+    }
+    return meta;
+  }
+
+  function renderPRCell(value) {
+    const list = Array.isArray(value) ? value : [];
+    if (!list.length) {
+      return '';
+    }
+    const entries = [];
+    for (const pr of list) {
+      const info = pr || {};
+      const numValue = typeof info.number === 'number' ? info.number : Number(info.number);
+      const hasNumber = Number.isFinite(numValue) && numValue > 0;
+      const numberText = hasNumber ? String(Math.trunc(numValue)) : '';
+      const stateRaw = info && info.state != null ? String(info.state) : '';
+      const state = stateRaw.trim().toLowerCase() || 'unknown';
+      const titleRaw = info && info.title != null ? String(info.title) : '';
+      const titleText = titleRaw.trim();
+      const tooltip = normalizePRTooltip(info.body);
+      const anchorLabel = hasNumber ? `#${numberText}` : (titleText || state || '#');
+      const ariaParts = [];
+      if (hasNumber) {
+        ariaParts.push(`PR #${numberText}`);
+      } else {
+        ariaParts.push('Pull request');
+        if (titleText) {
+          ariaParts.push(titleText);
+        }
+      }
+      if (state) {
+        ariaParts.push(state);
+      }
+      const ariaLabel = ariaParts.join(' ').trim();
+      let leading = escText(anchorLabel);
+      if (info.url) {
+        const attrs = [
+          `href="${escAttr(String(info.url))}"`,
+          'target="_blank"',
+          'rel="noopener noreferrer"',
+        ];
+        if (ariaLabel) {
+          attrs.push(`aria-label="${escAttr(ariaLabel)}"`);
+        }
+        if (tooltip) {
+          attrs.push(`title="${escAttr(tooltip)}"`);
+        }
+        leading = `<a ${attrs.join(' ')}>${escText(anchorLabel)}</a>`;
+      } else if (tooltip) {
+        leading = `<span title="${escAttr(tooltip)}">${leading}</span>`;
+      }
+      let titleSuffix = '';
+      if (hasNumber && titleText) {
+        titleSuffix = ` ${escText(titleText)}`;
+      } else if (!hasNumber && titleText && anchorLabel !== titleText) {
+        titleSuffix = ` ${escText(titleText)}`;
+      }
+      entries.push(`${leading}${titleSuffix} (${escText(state)})`);
+    }
+    return entries.join('; ');
+  }
+
+  function renderTableCell(key, row) {
+    const r = row || {};
+    switch (key) {
+      case 'kind':
+        return renderBadge(r.kind);
+      case 'author':
+        return escText(r.author);
+      case 'email':
+        return escText(r.email);
+      case 'date':
+        return escText(r.date);
+      case 'age_days': {
+        const ageRaw = (typeof r.age_days === 'number' && isFinite(r.age_days)) ? String(r.age_days) : (r.age_days === 0 ? '0' : '');
+        return escText(ageRaw);
+      }
+      case 'commit': {
+        const commitRaw = r.commit ? String(r.commit).slice(0, 8) : '';
+        return `<code>${escText(commitRaw)}</code>`;
+      }
+      case 'location': {
+        const fileRaw = r.file ? String(r.file) : '';
+        const lineRaw = (typeof r.line === 'number' && r.line > 0) ? String(r.line) : '';
+        return `<code>${escText(`${fileRaw}:${lineRaw}`)}</code>`;
+      }
+      case 'url': {
+        const urlRaw = r.url ? String(r.url) : '';
+        if (!urlRaw) {
+          return '';
+        }
+        return `<a class="link-icon" href="${escAttr(urlRaw)}" target="_blank" rel="noopener noreferrer" aria-label="GitHubで開く"><span aria-hidden="true">🔗</span></a>`;
+      }
+      case 'prs':
+        return renderPRCell(r.prs);
+      case 'comment':
+        return escText(r.comment);
+      case 'message':
+        return escText(r.message);
+      default:
+        return escText(r[key]);
+    }
+  }
+
+  function renderResultTable(data, options) {
+    const info = (data && typeof data === 'object') ? data : {};
+    const opts = options || {};
+    const rowsSource = opts.rows;
+    const rows = Array.isArray(rowsSource) ? rowsSource : (Array.isArray(info.items) ? info.items : []);
+    const errs = Array.isArray(info.errors) ? info.errors : [];
+    const parts = [];
+    if (errs.length > 0) {
+      let list = '<ul>';
+      for (const e of errs) {
+        const fileRaw = e && e.file ? e.file : '(unknown)';
+        const lineRaw = e && typeof e.line === 'number' && e.line > 0 ? String(e.line) : '—';
+        const loc = `${fileRaw}:${lineRaw}`;
+        const stage = e && e.stage ? e.stage : 'git';
+        list += `<li><code>${escText(loc)}</code> [${escText(stage)}] ${escText(e && e.message ? e.message : '')}</li>`;
+      }
+      list += '</ul>';
+      parts.push(`<div class="errors"><strong>${errs.length} error(s)</strong>${list}</div>`);
+    }
+    if (!rows || rows.length === 0) {
+      parts.push('<p>該当する結果はありません。</p>');
+      return parts.join('');
+    }
+    const headerMeta = buildHeaderMeta(info);
+    const activeKey = opts.sortKey ? String(opts.sortKey) : null;
+    const activeDesc = !!opts.sortDesc;
+    const head = headerMeta.map((meta) => {
+      const classes = ['sort-btn'];
+      if (activeKey === meta.key) {
+        classes.push(activeDesc ? 'desc' : 'asc');
+      }
+      const ariaSort = activeKey === meta.key ? (activeDesc ? 'descending' : 'ascending') : 'none';
+      return `<th aria-sort="${ariaSort}"><button type="button" class="${classes.join(' ')}" data-key="${escAttr(meta.key)}">${escText(meta.label)}</button></th>`;
+    }).join('');
+    let tableHTML = `<table><thead><tr>${head}</tr></thead><tbody>`;
+    for (const r of rows) {
+      const cells = [];
+      for (const meta of headerMeta) {
+        cells.push(`<td>${renderTableCell(meta.key, r, info)}</td>`);
+      }
+      tableHTML += `<tr>${cells.join('')}</tr>`;
+    }
+    tableHTML += '</tbody></table>';
+    parts.push(tableHTML);
+    return parts.join('');
+  }
+
+  function compareStrings(a, b) {
+    const sa = a == null ? '' : String(a).trim();
+    const sb = b == null ? '' : String(b).trim();
+    const emptyA = sa === '';
+    const emptyB = sb === '';
+    if (emptyA && emptyB) {
+      return 0;
+    }
+    if (emptyA) {
+      return 1;
+    }
+    if (emptyB) {
+      return -1;
+    }
+    if (sa < sb) {
+      return -1;
+    }
+    if (sa > sb) {
+      return 1;
+    }
+    return 0;
+  }
+
+  function compareNumbers(a, b) {
+    const na = typeof a === 'number' && isFinite(a) ? a : null;
+    const nb = typeof b === 'number' && isFinite(b) ? b : null;
+    if (na == null && nb == null) {
+      return 0;
+    }
+    if (na == null) {
+      return 1;
+    }
+    if (nb == null) {
+      return -1;
+    }
+    return na - nb;
+  }
+
+  function compareLocation(a, b) {
+    const fileA = a && a.file ? String(a.file) : '';
+    const fileB = b && b.file ? String(b.file) : '';
+    const fileCmp = compareStrings(fileA, fileB);
+    if (fileCmp !== 0) {
+      return fileCmp;
+    }
+    const lineA = a && typeof a.line === 'number' ? a.line : null;
+    const lineB = b && typeof b.line === 'number' ? b.line : null;
+    if (lineA == null && lineB == null) {
+      return 0;
+    }
+    if (lineA == null) {
+      return 1;
+    }
+    if (lineB == null) {
+      return -1;
+    }
+    return lineA - lineB;
+  }
+
+  function comparePRs(a, b) {
+    const listA = Array.isArray(a && a.prs) ? a.prs : [];
+    const listB = Array.isArray(b && b.prs) ? b.prs : [];
+    if (!listA.length && !listB.length) {
+      return 0;
+    }
+    if (!listA.length) {
+      return 1;
+    }
+    if (!listB.length) {
+      return -1;
+    }
+    const firstA = listA[0] || {};
+    const firstB = listB[0] || {};
+    const numCmp = compareNumbers(firstA.number, firstB.number);
+    if (numCmp !== 0) {
+      return numCmp;
+    }
+    const titleCmp = compareStrings(firstA.title, firstB.title);
+    if (titleCmp !== 0) {
+      return titleCmp;
+    }
+    return compareStrings(firstA.state, firstB.state);
+  }
+
+  function isValueEmptyForKey(row, key) {
+    const r = row || {};
+    switch (key) {
+      case 'age_days':
+        return !(typeof r.age_days === 'number' && isFinite(r.age_days));
+      case 'commit':
+      case 'date':
+      case 'author':
+      case 'email':
+      case 'kind':
+      case 'comment':
+      case 'message':
+      case 'url': {
+        const val = r[key];
+        return val == null || String(val).trim() === '';
+      }
+      case 'location': {
+        const file = r.file != null ? String(r.file).trim() : '';
+        const hasLine = typeof r.line === 'number' && r.line > 0;
+        return !file && !hasLine;
+      }
+      case 'prs':
+        return !(Array.isArray(r.prs) && r.prs.length > 0);
+      default: {
+        const val = r[key];
+        return val == null || String(val).trim() === '';
+      }
+    }
+  }
+
+  function compareRows(a, b, key) {
+    switch (key) {
+      case 'age_days':
+        return compareNumbers(a && a.age_days, b && b.age_days);
+      case 'commit':
+        return compareStrings(a && a.commit, b && b.commit);
+      case 'date':
+        return compareStrings(a && a.date, b && b.date);
+      case 'author':
+        return compareStrings(a && a.author, b && b.author);
+      case 'email':
+        return compareStrings(a && a.email, b && b.email);
+      case 'kind':
+        return compareStrings(a && a.kind, b && b.kind);
+      case 'comment':
+        return compareStrings(a && a.comment, b && b.comment);
+      case 'message':
+        return compareStrings(a && a.message, b && b.message);
+      case 'url':
+        return compareStrings(a && a.url, b && b.url);
+      case 'location':
+        return compareLocation(a, b);
+      case 'prs':
+        return comparePRs(a, b);
+      default:
+        return compareStrings(a && a[key], b && b[key]);
+    }
+  }
+
+  function sortRows(rows, key, desc) {
+    const base = Array.isArray(rows) ? rows.slice() : [];
+    if (!key) {
+      return base;
+    }
+    base.sort((left, right) => {
+      const leftEmpty = isValueEmptyForKey(left, key);
+      const rightEmpty = isValueEmptyForKey(right, key);
+      if (leftEmpty !== rightEmpty) {
+        return leftEmpty ? 1 : -1;
+      }
+      const cmp = compareRows(left, right, key);
+      return desc ? -cmp : cmp;
+    });
+    return base;
+  }
+
+  function attachSortHandlers() {
+    if (!resultTable) {
+      return;
+    }
+    const buttons = resultTable.querySelectorAll('th .sort-btn');
+    for (const btn of buttons) {
+      btn.addEventListener('click', (ev) => {
+        ev.preventDefault();
+        const key = btn.getAttribute('data-key');
+        if (!key) {
+          return;
+        }
+        if (sortKey === key) {
+          sortDesc = !sortDesc;
+        } else {
+          sortKey = key;
+          sortDesc = false;
+        }
+        renderTableWithSort();
+      });
+    }
+  }
+
+  function renderTableWithSort() {
+    const base = (latestResult && typeof latestResult === 'object') ? latestResult : {};
+    const sorted = sortRows(tableRows, sortKey, sortDesc);
+    if (resultTable) {
+      resultTable.innerHTML = renderResultTable(base, { rows: sorted, sortKey, sortDesc });
+      attachSortHandlers();
+    }
+  }
+
+  function updateResultData(data) {
+    latestResult = (data && typeof data === 'object') ? data : null;
+    tableRows = Array.isArray(latestResult && latestResult.items) ? latestResult.items.slice() : [];
+    sortKey = null;
+    sortDesc = false;
+    renderTableWithSort();
+    const count = tableRows.length;
+    if (resultCount) {
+      resultCount.textContent = `結果: ${count} 件`;
+    }
+    if (exportJSONBtn) {
+      exportJSONBtn.disabled = !latestResult || !tableRows.length;
+    }
+    if (exportTSVBtn) {
+      exportTSVBtn.disabled = !latestResult || !tableRows.length;
+    }
+    if (resultErrors) {
+      const errs = Array.isArray(latestResult && latestResult.errors) ? latestResult.errors : [];
+      if (errs.length > 0) {
+        resultErrors.hidden = false;
+        resultErrors.textContent = `エラー: ${errs.length} 件`;
+      } else {
+        resultErrors.hidden = true;
+        resultErrors.textContent = '';
+      }
+    }
+  }
+
+  function resetProgressUI() {
+    if (!progressStage) {
+      return;
+    }
+    progressStage.textContent = 'scan';
+    if (progressStats) {
+      progressStats.textContent = '0/— done';
+    }
+    if (progressETA) {
+      progressETA.textContent = 'ETA: —';
+    }
+    if (progressRate) {
+      progressRate.textContent = 'Rate: —';
+    }
+    if (progressElapsed) {
+      progressElapsed.textContent = 'Elapsed: —';
+    }
+    updateProgressBar(0, false);
+    setStepper('scan');
+  }
+  function showProgressUI() {
+    if (!progressWrap) {
+      return;
+    }
+    progressWrap.hidden = false;
+    progressWrap.classList.remove('is-hidden');
+    progressWrap.setAttribute('aria-busy', 'true');
+    resetProgressUI();
+  }
+
+  function hideProgressUI() {
+    if (!progressWrap) {
+      return;
+    }
+    progressWrap.hidden = true;
+    progressWrap.classList.add('is-hidden');
+    progressWrap.removeAttribute('aria-busy');
+    lastSnap = null;
+    if (rafId && typeof cancelAnimationFrame === 'function') {
+      cancelAnimationFrame(rafId);
+      rafId = 0;
+    }
+    if (progressCancel) {
+      progressCancel.onclick = null;
+    }
+  }
+
+  function setStepper(stage) {
+    const stages = { scan: stScan, attr: stAttr, pr: stPr };
+    for (const key of Object.keys(stages)) {
+      const el = stages[key];
+      if (!el) {
+        continue;
+      }
+      el.removeAttribute('data-active');
+      el.removeAttribute('data-status');
+    }
+    if (stage === 'scan') {
+      if (stScan) {
+        stScan.setAttribute('data-active', 'true');
+      }
+    } else if (stage === 'attr') {
+      if (stScan) {
+        stScan.setAttribute('data-status', 'done');
+      }
+      if (stAttr) {
+        stAttr.setAttribute('data-active', 'true');
+      }
+    } else if (stage === 'pr') {
+      if (stScan) {
+        stScan.setAttribute('data-status', 'done');
+      }
+      if (stAttr) {
+        stAttr.setAttribute('data-status', 'done');
+      }
+      if (stPr) {
+        stPr.setAttribute('data-active', 'true');
+      }
+    }
+  }
+
+  function togglePRStepVisibility(enabled) {
+    if (!stPr) {
+      return;
+    }
+    if (enabled) {
+      stPr.classList.remove('is-hidden');
+    } else {
+      stPr.classList.add('is-hidden');
+      stPr.removeAttribute('data-active');
+      stPr.removeAttribute('data-status');
+    }
+  }
+
+  function updateProgressBar(percent, determinate) {
+    const pct = Math.max(0, Math.min(100, percent || 0));
+    if (!progressMeter) {
+      return;
+    }
+    if (determinate) {
+      progressMeter.max = 100;
+      progressMeter.value = Math.round(pct);
+      progressMeter.removeAttribute('data-indeterminate');
+    } else {
+      progressMeter.removeAttribute('value');
+      progressMeter.removeAttribute('max');
+      progressMeter.setAttribute('data-indeterminate', 'true');
+    }
+  }
+
+  function renderProgressOnce() {
+    rafId = 0;
+    if (!lastSnap) {
+      return;
+    }
+    const s = lastSnap;
+    const nf = (typeof Intl !== 'undefined' && Intl.NumberFormat) ? new Intl.NumberFormat() : { format: (v) => String(v) };
+    if (progressStage) {
+      progressStage.textContent = s.stage || '';
+    }
+    setStepper(s.stage);
+    const determinate = !!(s.total && s.total > 0);
+    let percent = 0;
+    if (determinate) {
+      percent = (s.done / s.total) * 100;
+    }
+    updateProgressBar(percent, determinate);
+    const totalLabel = determinate ? nf.format(s.total) : '—';
+    const statText = `${nf.format(s.done || 0)}/${totalLabel} done`;
+    const rateLabel = (typeof s.rate_per_sec === 'number' && isFinite(s.rate_per_sec)) ? `${nf.format(Number(s.rate_per_sec.toFixed(1)))}/sec` : '—';
+    const fmtEta = (sec) => {
+      if (!(typeof sec === 'number' && isFinite(sec))) {
+        return '—';
+      }
+      const mm = Math.floor(sec / 60);
+      const ss = Math.round(sec % 60);
+      return `${nf.format(Number(sec.toFixed(1)))}s (${mm}:${String(ss).padStart(2, '0')})`;
+    };
+    const etaLabel = fmtEta(s.eta_sec_p50);
+    const elapsedLabel = (typeof s.elapsed_sec === 'number' && isFinite(s.elapsed_sec)) ? `${s.elapsed_sec.toFixed(1)}s` : '—';
+    if (progressStats) {
+      progressStats.textContent = statText;
+    }
+    if (progressRate) {
+      progressRate.textContent = `Rate: ${rateLabel}`;
+    }
+    if (progressETA) {
+      progressETA.textContent = `ETA: ${etaLabel}`;
+    }
+    if (progressElapsed) {
+      progressElapsed.textContent = `Elapsed: ${elapsedLabel}`;
+    }
+  }
+
+  function scheduleRender() {
+    if (typeof requestAnimationFrame !== 'function') {
+      renderProgressOnce();
+      return;
+    }
+    if (rafId) {
+      return;
+    }
+    rafId = requestAnimationFrame(renderProgressOnce);
+  }
+
+  function closeStream() {
+    if (es) {
+      try { es.close(); } catch (_err) {}
+      es = null;
+    }
+  }
+
+  function cancelScan() {
+    closeStream();
+    if (fetchAbort) {
+      try {
+        fetchAbort.abort();
+      } catch (_err) {}
+      fetchAbort = null;
+    }
+    hideProgressUI();
+  }
+
+  if (cancelBtn) {
+    cancelBtn.addEventListener('click', () => {
+      cancelScan();
+    });
+  }
+
+  function startScanWithFetch(q) {
+    hideProgressUI();
+    if (resultTable) {
+      resultTable.innerHTML = '';
+    }
+    latestResult = null;
+    tableRows = [];
+    sortKey = null;
+    sortDesc = false;
+    fetchAbort = new AbortController();
+    const { signal } = fetchAbort;
+    fetch(`/api/scan?${q.toString()}`, { signal })
+      .then((res) => res.text().then((raw) => ({ res, raw })))
+      .then(({ res, raw }) => {
+        if (!res.ok) {
+          let msg = `HTTP ${res.status}`;
+          if (res.statusText) {
+            msg += ` ${res.statusText}`;
+          }
+          const trimmed = raw.trim();
+          if (trimmed) {
+            msg += `: ${trimmed}`;
+          }
+          throw new Error(msg);
+        }
+        let data = null;
+        const trimmed = raw.trim();
+        if (trimmed !== '') {
+          data = JSON.parse(trimmed);
+        }
+        updateResultData(data);
+      })
+      .catch((err) => {
+        if (err && err.name === 'AbortError') {
+          return;
+        }
+        console.error(err);
+        showError(err instanceof Error ? err.message : String(err));
+      })
+      .finally(() => {
+        fetchAbort = null;
+      });
+  }
+
+  function startScanWithSSE(q) {
+    cancelScan();
+    if (resultTable) {
+      resultTable.innerHTML = '';
+    }
+    latestResult = null;
+    tableRows = [];
+    sortKey = null;
+    sortDesc = false;
+    showProgressUI();
+    try {
+      es = new EventSource(`/api/scan/stream?${q.toString()}`);
+    } catch (err) {
+      hideProgressUI();
+      showError(err instanceof Error ? err.message : String(err));
+      return;
+    }
+
+    es.addEventListener('progress', (ev) => {
+      try {
+        lastSnap = JSON.parse(ev.data);
+        scheduleRender();
+      } catch (parseErr) {
+        console.warn('progress parse failed', parseErr);
+      }
+    });
+
+    es.addEventListener('result', (ev) => {
+      try {
+        const res = JSON.parse(ev.data);
+        hideProgressUI();
+        updateResultData(res);
+      } catch (parseErr) {
+        console.error(parseErr);
+        showError(parseErr instanceof Error ? parseErr.message : String(parseErr));
+      } finally {
+        closeStream();
+      }
+    });
+
+    const handleServerError = (ev) => {
+      if (!ev || typeof ev.data === 'undefined') {
+        return;
+      }
+      try {
+        const payload = JSON.parse(ev.data || '{}');
+        showError(payload && payload.message ? payload.message : 'stream error');
+      } catch (parseErr) {
+        showError(parseErr instanceof Error ? parseErr.message : String(parseErr));
+      }
+      hideProgressUI();
+      closeStream();
+    };
+
+    es.addEventListener('error', handleServerError);
+    es.addEventListener('server_error', handleServerError);
+
+    es.onerror = (ev) => {
+      if (ev && typeof ev.data !== 'undefined') {
+        return;
+      }
+      if (!es) {
+        return;
+      }
+      if (progressStats) {
+        const label = (lastSnap && es.readyState === EventSource.CONNECTING) ? '再接続中…' : '接続中…';
+        progressStats.textContent = label;
+      }
+    };
+
+    if (progressCancel) {
+      progressCancel.onclick = () => {
+        cancelScan();
+      };
+    }
+  }
+
+  function toCSVList(raw) {
+    const values = Array.isArray(raw) ? raw : [raw];
+    const out = [];
+    for (const val of values) {
+      if (val == null) {
+        continue;
+      }
+      const pieces = String(val)
+        .split(/[\n,]/)
+        .map((s) => s.trim())
+        .filter((s) => s !== '');
+      out.push(...pieces);
+    }
+    return out;
+  }
+
+  function tokenizeInput(value) {
+    if (!value) {
+      return [];
+    }
+    return String(value)
+      .split(/[\s,]+/)
+      .map((s) => s.trim())
+      .filter((s) => s !== '');
+  }
+
+  function buildParamsFromForm() {
+    const params = new URLSearchParams();
+    const elements = Array.from(form.elements);
+    for (const el of elements) {
+      if (!(el instanceof HTMLInputElement || el instanceof HTMLSelectElement || el instanceof HTMLTextAreaElement)) {
+        continue;
+      }
+      if (!el.name || el.disabled) {
+        continue;
+      }
+      const name = el.name;
+      if (el.type === 'checkbox') {
+        if (!el.checked) {
+          continue;
+        }
+        params.append(name, el.value || '1');
+        continue;
+      }
+      if (el instanceof HTMLInputElement && el.type === 'radio') {
+        if (!el.checked) {
+          continue;
+        }
+        params.append(name, el.value);
+        continue;
+      }
+      if (el instanceof HTMLSelectElement && el.multiple) {
+        for (const option of Array.from(el.selectedOptions)) {
+          params.append(name, option.value);
+        }
+        continue;
+      }
+      if (el.dataset.multi != null) {
+        const values = toCSVList(el.value || '');
+        for (const value of values) {
+          params.append(name, value);
+        }
+        continue;
+      }
+      if (el.dataset.tokenize != null) {
+        const tokens = tokenizeInput(el.value || '');
+        for (const token of tokens) {
+          params.append(name, token);
+        }
+        continue;
+      }
+      const value = (el.value || '').trim();
+      if (value !== '') {
+        params.append(name, value);
+      }
+    }
+
+    params.delete('string_scan');
+    const scanValue = form.querySelector('input[name="string_scan"]:checked')?.value;
+    if (scanValue === 'comments_only') {
+      params.set('comments_only', '1');
+      params.delete('include_strings');
+      params.delete('no_strings');
+    } else if (scanValue === 'include_strings') {
+      params.set('include_strings', '1');
+      params.delete('comments_only');
+      params.delete('no_strings');
+    } else if (scanValue === 'no_strings') {
+      params.set('no_strings', '1');
+      params.delete('include_strings');
+      params.delete('comments_only');
+    }
+
+    const fields = params.getAll('fields');
+    let autoEnabled = false;
+    if (fields.some((f) => ['url', 'commit_url'].includes(f))) {
+      params.set('with_commit_link', '1');
+      const cb = form.elements.namedItem('with_commit_link');
+      if (cb instanceof HTMLInputElement && cb.type === 'checkbox') {
+        cb.checked = true;
+      }
+      autoEnabled = true;
+    }
+    if (fields.some((f) => ['pr', 'prs', 'pr_urls'].includes(f))) {
+      params.set('with_pr_links', '1');
+      const cb = form.elements.namedItem('with_pr_links');
+      if (cb instanceof HTMLInputElement && cb.type === 'checkbox') {
+        cb.checked = true;
+      }
+      autoEnabled = true;
+    }
+    if (fieldAutoNote) {
+      fieldAutoNote.hidden = !autoEnabled;
+    }
+    togglePRVisibility(params.get('with_pr_links') === '1');
+
+    const jobs = form.elements.namedItem('jobs');
+    if (jobs instanceof HTMLInputElement && jobs.value.trim() === '') {
+      params.delete('jobs');
+    }
+
+    return params;
+  }
+
+  function togglePRVisibility(enabled) {
+    togglePRStepVisibility(enabled);
+    if (prOptions) {
+      prOptions.hidden = !enabled;
+      prOptions.classList.toggle('is-hidden', !enabled);
+    }
+  }
+
+  function updateShare(params) {
+    const query = params.toString();
+    if (window.history && typeof window.history.replaceState === 'function') {
+      const url = `${window.location.pathname}?${query}`;
+      window.history.replaceState(null, '', url);
+    }
+    const shareURL = new URL(window.location.href);
+    shareURL.search = query;
+    shareURL.hash = '';
+    if (shareURLEl) {
+      shareURLEl.value = shareURL.toString();
+    }
+  }
+  function shellQuote(value) {
+    if (value === '') {
+      return "''";
+    }
+    if (/^[A-Za-z0-9_.,@\/-]+$/.test(value)) {
+      return value;
+    }
+    return `'${String(value).replace(/'/g, "'\\''")}'`;
+  }
+
+  function paramsToCLI(params) {
+    const args = ['todox'];
+    const getAll = (key) => params.getAll(key);
+
+    const type = params.get('type');
+    if (type && type !== 'both') {
+      args.push('--type', type);
+    }
+    const mode = params.get('mode');
+    if (mode && mode !== 'last') {
+      args.push('--mode', mode);
+    }
+    const author = params.get('author');
+    if (author) {
+      args.push('--author', author);
+    }
+    const detect = params.get('detect');
+    if (detect && detect !== 'auto') {
+      args.push('--detect', detect);
+    }
+    const detectLangs = getAll('detect_langs');
+    if (detectLangs.length) {
+      args.push('--detect-langs', detectLangs.join(','));
+    }
+    const tags = getAll('tags');
+    if (tags.length) {
+      args.push('--tags', tags.join(','));
+    }
+    if (params.get('comments_only') === '1') {
+      args.push('--comments-only');
+    } else if (params.get('include_strings') === '1') {
+      args.push('--include-strings');
+    } else if (params.get('no_strings') === '1') {
+      args.push('--no-strings');
+    }
+    const maxFileBytes = params.get('max_file_bytes');
+    if (maxFileBytes) {
+      args.push('--max-file-bytes', maxFileBytes);
+    }
+    if (params.get('no_prefilter') === '1') {
+      args.push('--no-prefilter');
+    }
+    const pathValues = getAll('path');
+    for (const value of pathValues) {
+      args.push('--path', value);
+    }
+    const excludeValues = getAll('exclude');
+    for (const value of excludeValues) {
+      args.push('--exclude', value);
+    }
+    const regexValues = getAll('path_regex');
+    for (const value of regexValues) {
+      args.push('--path-regex', value);
+    }
+    if (params.get('exclude_typical') === '1') {
+      args.push('--exclude-typical');
+    }
+    const fields = getAll('fields');
+    if (fields.length) {
+      args.push('--fields', fields.join(','));
+    }
+    if (params.get('with_comment') === '1') {
+      args.push('--with-comment');
+    }
+    if (params.get('with_message') === '1') {
+      args.push('--with-message');
+    }
+    if (params.get('with_age') === '1') {
+      args.push('--with-age');
+    }
+    if (params.get('with_commit_link') === '1') {
+      args.push('--with-commit-link');
+    }
+    if (params.get('with_pr_links') === '1') {
+      args.push('--with-pr-links');
+      const prState = params.get('pr_state');
+      if (prState) {
+        args.push('--pr-state', prState);
+      }
+      const prLimit = params.get('pr_limit');
+      if (prLimit) {
+        args.push('--pr-limit', prLimit);
+      }
+      const prPrefer = params.get('pr_prefer');
+      if (prPrefer) {
+        args.push('--pr-prefer', prPrefer);
+      }
+    }
+    const truncate = params.get('truncate');
+    if (truncate) {
+      args.push('--truncate', truncate);
+    }
+    const truncComment = params.get('truncate_comment');
+    if (truncComment) {
+      args.push('--truncate-comment', truncComment);
+    }
+    const truncMessage = params.get('truncate_message');
+    if (truncMessage) {
+      args.push('--truncate-message', truncMessage);
+    }
+    const sort = params.get('sort');
+    if (sort) {
+      args.push('--sort', sort);
+    }
+    const ignoreWS = params.get('ignore_ws');
+    if (ignoreWS === '0') {
+      args.push('--no-ignore-ws');
+    }
+    const jobs = params.get('jobs');
+    if (jobs) {
+      args.push('--jobs', jobs);
+    }
+    const repo = params.get('repo');
+    if (repo) {
+      args.push('--repo', repo);
+    }
+
+    const cli = args.map((arg, index) => (index === 0 ? arg : shellQuote(arg))).join(' ');
+    if (cliOutput) {
+      cliOutput.value = cli;
+    }
+    if (cliPreview) {
+      cliPreview.textContent = cli;
+    }
+    if (cliHelp) {
+      const hints = [];
+      if (detect && detect !== 'auto') {
+        hints.push('`--detect` 検出エンジン');
+      }
+      if (fields.length) {
+        hints.push('`--fields` 表示列');
+      }
+      if (params.get('with_pr_links') === '1') {
+        hints.push('`--with-pr-links` PR 情報');
+      }
+      if (params.get('with_commit_link') === '1') {
+        hints.push('`--with-commit-link` コミットURL');
+      }
+      if (params.get('with_comment') === '1') {
+        hints.push('`--with-comment` コメント出力');
+      }
+      if (params.get('with_message') === '1') {
+        hints.push('`--with-message` コミットメッセージ');
+      }
+      if (params.get('with_age') === '1') {
+        hints.push('`--with-age` 経過日数');
+      }
+      if (params.get('comments_only') === '1' || params.get('include_strings') === '1' || params.get('no_strings') === '1') {
+        hints.push('コメント/文字列の走査モード');
+      }
+      cliHelp.textContent = hints.length ? hints.join(' / ') : '基本設定のみです。';
+    }
+  }
+
+  function updateDerivedState() {
+    const params = buildParamsFromForm();
+    updateShare(params);
+    paramsToCLI(params);
+    if (window.localStorage) {
+      try {
+        window.localStorage.setItem(LOCAL_STORAGE_KEY, params.toString());
+      } catch (_err) {}
+    }
+    return params;
+  }
+
+  function startScan(ev) {
+    ev.preventDefault();
+    hideError();
+    const params = updateDerivedState();
+    if ('EventSource' in window) {
+      startScanWithSSE(params);
+    } else {
+      startScanWithFetch(params);
+    }
+  }
+
+  form.addEventListener('submit', startScan);
+  form.addEventListener('input', () => {
+    updateDerivedState();
+  });
+  form.addEventListener('change', () => {
+    updateDerivedState();
+  });
+
+  const sortQuick = document.getElementById('sort-quick');
+  if (sortQuick) {
+    sortQuick.addEventListener('change', () => {
+      const value = sortQuick.value;
+      const sortField = form.elements.namedItem('sort');
+      if (sortField instanceof HTMLInputElement) {
+        sortField.value = value || '';
+        updateDerivedState();
+      }
+    });
+  }
+
+  const copyButtons = document.querySelectorAll('[data-copy-target]');
+  copyButtons.forEach((btn) => {
+    const targetSel = btn.getAttribute('data-copy-target');
+    if (!targetSel) {
+      return;
+    }
+    btn.addEventListener('click', async () => {
+      const target = document.querySelector(targetSel);
+      if (!(target instanceof HTMLInputElement || target instanceof HTMLTextAreaElement || target instanceof HTMLElement)) {
+        return;
+      }
+      try {
+        let text = '';
+        if (target instanceof HTMLInputElement || target instanceof HTMLTextAreaElement) {
+          text = target.value;
+        } else {
+          text = target.textContent || '';
+        }
+        if (navigator.clipboard && typeof navigator.clipboard.writeText === 'function') {
+          await navigator.clipboard.writeText(text);
+        } else {
+          if (target instanceof HTMLInputElement || target instanceof HTMLTextAreaElement) {
+            target.select();
+            target.setSelectionRange(0, text.length);
+            document.execCommand('copy');
+          } else {
+            const range = document.createRange();
+            range.selectNodeContents(target);
+            const selection = window.getSelection();
+            if (selection) {
+              selection.removeAllRanges();
+              selection.addRange(range);
+              document.execCommand('copy');
+              selection.removeAllRanges();
+            }
+          }
+        }
+        btn.classList.add('copied');
+        window.setTimeout(() => btn.classList.remove('copied'), 1200);
+      } catch (_err) {}
+    });
+  });
+
+  if (resetBtn) {
+    resetBtn.addEventListener('click', () => {
+      form.reset();
+      syncRangePairs();
+      togglePRVisibility(false);
+      updateDerivedState();
+    });
+  }
+
+  function syncRangePairs() {
+    const pairs = form.querySelectorAll('.range-pair');
+    pairs.forEach((pair) => {
+      const range = pair.querySelector('input[type="range"]');
+      const number = pair.querySelector('input[type="number"]');
+      if (!(range instanceof HTMLInputElement) || !(number instanceof HTMLInputElement)) {
+        return;
+      }
+      const placeholder = number.getAttribute('placeholder');
+      const currentValue = number.value !== '' ? number.value : (placeholder || '0');
+      range.value = currentValue;
+      if (pair.dataset.initialized === '1') {
+        return;
+      }
+      range.addEventListener('input', () => {
+        number.value = range.value;
+        updateDerivedState();
+      });
+      number.addEventListener('input', () => {
+        if (number.value === '') {
+          range.value = placeholder || '0';
+        } else {
+          range.value = number.value;
+        }
+      });
+      pair.dataset.initialized = '1';
+    });
+  }
+
+  syncRangePairs();
+
+  function parseBoolish(value) {
+    const normalized = String(value).toLowerCase();
+    return normalized === '1' || normalized === 'true' || normalized === 'yes' || normalized === 'on';
+  }
+
+  function applyParamsToForm(params) {
+    form.reset();
+    const entries = Array.from(params.entries());
+    const grouped = new Map();
+    for (const [key, value] of entries) {
+      if (!grouped.has(key)) {
+        grouped.set(key, []);
+      }
+      grouped.get(key).push(value);
+    }
+
+    const setTextareaValues = (name, values) => {
+      const el = form.elements.namedItem(name);
+      if (el instanceof HTMLTextAreaElement) {
+        el.value = values.join('\n');
+      }
+    };
+
+    const setSelectMultiple = (name, values) => {
+      const el = form.elements.namedItem(name);
+      if (el instanceof HTMLSelectElement && el.multiple) {
+        for (const option of Array.from(el.options)) {
+          option.selected = values.includes(option.value);
+        }
+      }
+    };
+
+    for (const [key, values] of grouped.entries()) {
+      if (['path', 'exclude', 'path_regex'].includes(key)) {
+        setTextareaValues(key, values);
+      } else if (['detect_langs', 'tags'].includes(key)) {
+        const el = form.elements.namedItem(key);
+        if (el instanceof HTMLInputElement) {
+          el.value = values.join(',');
+        }
+      } else if (key === 'fields') {
+        setSelectMultiple('fields', values);
+      } else if (['comments_only', 'include_strings', 'no_strings'].includes(key)) {
+        const boolVal = parseBoolish(values[values.length - 1]);
+        if (boolVal) {
+          const radioValue = key;
+          const target = form.querySelector(`input[name="string_scan"][value="${cssEscape(radioValue)}"]`);
+          if (target instanceof HTMLInputElement) {
+            target.checked = true;
+          }
+        }
+      } else {
+        const el = form.elements.namedItem(key);
+        const latest = values[values.length - 1];
+        if (el instanceof HTMLInputElement) {
+          if (el.type === 'checkbox') {
+            el.checked = parseBoolish(latest);
+          } else if (el.type === 'radio') {
+            const radio = form.querySelector(`input[name="${cssEscape(key)}"][value="${cssEscape(latest)}"]`);
+            if (radio instanceof HTMLInputElement) {
+              radio.checked = true;
+            }
+          } else {
+            el.value = latest;
+          }
+        } else if (el instanceof HTMLSelectElement) {
+          el.value = latest;
+        } else if (el instanceof HTMLTextAreaElement) {
+          el.value = latest;
+        }
+      }
+    }
+
+    const withPR = parseBoolish(params.get('with_pr_links') || '0');
+    togglePRVisibility(withPR);
+    syncRangePairs();
+  }
+
+  function loadInitialState() {
+    const query = window.location.search ? window.location.search.slice(1) : '';
+    const stored = window.localStorage ? window.localStorage.getItem(LOCAL_STORAGE_KEY) : '';
+    let source = '';
+    if (query) {
+      source = query;
+    } else if (stored) {
+      source = stored;
+    }
+    if (source) {
+      try {
+        const params = new URLSearchParams(source);
+        applyParamsToForm(params);
+      } catch (_err) {}
+    }
+    updateDerivedState();
+  }
+
+  loadInitialState();
+
+  function downloadBlob(filename, blob) {
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = filename;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+  }
+
+  function exportJSON() {
+    if (!latestResult) {
+      return;
+    }
+    const blob = new Blob([JSON.stringify(latestResult, null, 2)], { type: 'application/json' });
+    downloadBlob('todox-results.json', blob);
+  }
+
+  function getHeaderMetaForExport() {
+    return buildHeaderMeta(latestResult || {});
+  }
+
+  function valueForExport(key, row) {
+    const r = row || {};
+    switch (key) {
+      case 'kind':
+        return String(r.kind ?? '');
+      case 'author':
+        return String(r.author ?? '');
+      case 'email':
+        return String(r.email ?? '');
+      case 'date':
+        return String(r.date ?? '');
+      case 'age_days':
+        return (typeof r.age_days === 'number' && isFinite(r.age_days)) ? String(r.age_days) : '';
+      case 'commit':
+        return String(r.commit ?? '');
+      case 'location':
+        return `${r.file ?? ''}:${r.line ?? ''}`;
+      case 'url':
+        return String(r.url ?? '');
+      case 'prs': {
+        const list = Array.isArray(r.prs) ? r.prs : [];
+        return list.map((pr) => {
+          const info = pr || {};
+          const num = info.number != null ? `#${info.number}` : '';
+          const title = info.title ? ` ${info.title}` : '';
+          const state = info.state ? ` (${info.state})` : '';
+          return `${num}${title}${state}`.trim();
+        }).join('; ');
+      }
+      case 'comment':
+        return String(r.comment ?? '');
+      case 'message':
+        return String(r.message ?? '');
+      default:
+        return String(r[key] ?? '');
+    }
+  }
+
+  function exportTSV() {
+    if (!latestResult) {
+      return;
+    }
+    const rows = Array.isArray(latestResult.items) ? latestResult.items : [];
+    if (!rows.length) {
+      return;
+    }
+    const headerMeta = getHeaderMetaForExport();
+    const lines = [];
+    lines.push(headerMeta.map((meta) => meta.label).join('\t'));
+    for (const row of rows) {
+      const cols = headerMeta.map((meta) => valueForExport(meta.key, row).replace(/\t/g, ' ').replace(/\r?\n/g, ' '));
+      lines.push(cols.join('\t'));
+    }
+    const blob = new Blob([lines.join('\n')], { type: 'text/tab-separated-values' });
+    downloadBlob('todox-results.tsv', blob);
+  }
+
+  if (exportJSONBtn) {
+    exportJSONBtn.addEventListener('click', exportJSON);
+  }
+  if (exportTSVBtn) {
+    exportTSVBtn.addEventListener('click', exportTSV);
+  }
+
+  function setField(name, value) {
+    const el = form.elements.namedItem(name);
+    if (!el) {
+      return;
+    }
+    if (el instanceof HTMLInputElement) {
+      if (el.type === 'checkbox') {
+        el.checked = parseBoolish(value);
+      } else {
+        el.value = value;
+      }
+    } else if (el instanceof HTMLSelectElement) {
+      el.value = value;
+    } else if (el instanceof HTMLTextAreaElement) {
+      el.value = value;
+    }
+  }
+
+  function applyPreset(name) {
+    switch (name) {
+      case 'precise':
+        setField('detect', 'parse');
+        break;
+      case 'fast':
+        setField('detect', 'regex');
+        ['with_comment', 'with_message', 'with_pr_links', 'with_commit_link'].forEach((key) => {
+          const el = form.elements.namedItem(key);
+          if (el instanceof HTMLInputElement && el.type === 'checkbox') {
+            el.checked = false;
+          }
+        });
+        break;
+      case 'oldest':
+        {
+          const el = form.elements.namedItem('with_age');
+          if (el instanceof HTMLInputElement && el.type === 'checkbox') {
+            el.checked = true;
+          }
+          setField('sort', '-age');
+        }
+        break;
+      case 'prs':
+        {
+          const prCheckbox = form.elements.namedItem('with_pr_links');
+          if (prCheckbox instanceof HTMLInputElement && prCheckbox.type === 'checkbox') {
+            prCheckbox.checked = true;
+          }
+          setField('pr_state', 'all');
+          setField('pr_limit', '5');
+          setField('pr_prefer', 'open');
+          const fieldsSelect = form.elements.namedItem('fields');
+          if (fieldsSelect instanceof HTMLSelectElement) {
+            for (const option of Array.from(fieldsSelect.options)) {
+              option.selected = false;
+            }
+            ['type', 'author', 'date', 'prs'].forEach((value) => {
+              for (const option of Array.from(fieldsSelect.options)) {
+                if (option.value === value) {
+                  option.selected = true;
+                }
+              }
+            });
+          }
+        }
+        break;
+      case 'concise':
+        {
+          const comment = form.elements.namedItem('with_comment');
+          if (comment instanceof HTMLInputElement && comment.type === 'checkbox') {
+            comment.checked = true;
+          }
+          const message = form.elements.namedItem('with_message');
+          if (message instanceof HTMLInputElement && message.type === 'checkbox') {
+            message.checked = true;
+          }
+          const truncate = form.elements.namedItem('truncate');
+          if (truncate instanceof HTMLInputElement) {
+            truncate.value = '80';
+          }
+        }
+        break;
+      case 'whitespace':
+        setField('ignore_ws', '0');
+        break;
+      case 'baseline':
+        form.reset();
+        break;
+      default:
+        return;
+    }
+    syncRangePairs();
+    updateDerivedState();
+  }
+
+  if (presetWrap) {
+    presetWrap.addEventListener('click', (ev) => {
+      const target = ev.target;
+      if (!(target instanceof HTMLElement)) {
+        return;
+      }
+      const preset = target.getAttribute('data-preset');
+      if (!preset) {
+        return;
+      }
+      applyPreset(preset);
+    });
+  }
+
+})();

--- a/internal/web/templates/index.html
+++ b/internal/web/templates/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="ja">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -7,879 +7,305 @@
   <link rel="stylesheet" href="{{.StylesPath}}">
 </head>
 <body>
-  <h2>todox</h2>
-  <div id="error-banner" class="error-banner" role="alert" aria-live="assertive">
-    <span id="error-message"></span>
-    <button type="button" id="error-close" aria-label="Close">&times;</button>
+  <div class="app-shell">
+    <header class="toolbar" role="banner">
+      <button type="button" class="btn btn-icon" id="collapseFilters" aria-label="フィルターを隠す" aria-controls="filter-panel" aria-expanded="true" data-toggle="#filter-panel">×</button>
+      <h1 class="app-title">todox</h1>
+      <div class="toolbar-presets" id="preset-chips" role="group" aria-label="プリセット">
+        <button type="button" class="chip" data-preset="precise">Precise</button>
+        <button type="button" class="chip" data-preset="fast">Fast</button>
+        <button type="button" class="chip" data-preset="oldest">Oldest first</button>
+        <button type="button" class="chip" data-preset="prs">PR重視</button>
+        <button type="button" class="chip" data-preset="concise">短く見やすく</button>
+        <button type="button" class="chip" data-preset="whitespace">Whitespace厳密</button>
+        <button type="button" class="chip" data-preset="baseline">デフォルトに戻す</button>
+      </div>
+      <details id="options-popover" class="popover">
+        <summary class="btn btn-ghost" id="btnOptions">⚙ オプション</summary>
+        <div class="popover__content" id="optionsBody" role="group" aria-label="CLI オプションプレビュー">
+          <pre class="code" id="cli-preview" aria-live="polite"></pre>
+          <button type="button" class="btn btn-secondary" data-copy-target="#cli-preview">コピー</button>
+          <p class="muted" id="cli-help"></p>
+        </div>
+      </details>
+    </header>
+
+    <main class="layout" role="main">
+      <div class="filters">
+        <section id="filter-panel" class="panel">
+          <form id="opts" class="options-form" novalidate>
+            <fieldset class="section">
+              <legend>基本 <button type="button" class="help-toggle" aria-expanded="false">?</button></legend>
+              <div class="help-text" hidden>
+                よく使う検索条件です。タグ種類、 blame の基準、著者フィルタ、ソート順を指定できます。
+              </div>
+              <div class="field-grid">
+                <label for="type">マーカー種別
+                  <select id="type" name="type">
+                    <option value="both">TODO と FIXME</option>
+                    <option value="todo">TODO のみ</option>
+                    <option value="fixme">FIXME のみ</option>
+                  </select>
+                </label>
+                <label for="mode">著者の定義
+                  <select id="mode" name="mode">
+                    <option value="last">最終コミット (last)</option>
+                    <option value="first">初回コミット (first)</option>
+                  </select>
+                </label>
+                <label for="author">著者フィルタ（拡張正規表現）
+                  <input id="author" name="author" type="text" placeholder="Alice|alice@example.com">
+                </label>
+                <label for="sort-quick">並び替え（簡易）
+                  <select id="sort-quick">
+                    <option value="">(変更しない)</option>
+                    <option value="-age">古い順 (-age)</option>
+                    <option value="age">新しい順 (age)</option>
+                    <option value="author">著者 (author)</option>
+                    <option value="file">ファイル (file)</option>
+                  </select>
+                </label>
+                <label for="sort">並び替え（詳細ビルダー）
+                  <input id="sort" name="sort" type="text" placeholder="-age,file">
+                </label>
+              </div>
+            </fieldset>
+
+            <fieldset class="section">
+              <legend>検出エンジン <button type="button" class="help-toggle" aria-expanded="false">?</button></legend>
+              <div class="help-text" hidden>
+                解析方式や対象言語を制御します。コメント／文字列の扱いもここで切り替えます。
+              </div>
+              <div class="field-grid">
+                <div class="control">
+                  <span class="control-label">文字列走査</span>
+                  <div class="segmented" role="radiogroup" aria-label="文字列走査">
+                    <input type="radio" id="scan-comments" name="string_scan" value="comments_only" checked>
+                    <label for="scan-comments">コメントのみ</label>
+                    <input type="radio" id="scan-mixed" name="string_scan" value="include_strings">
+                    <label for="scan-mixed">コメント＋文字列</label>
+                    <input type="radio" id="scan-none" name="string_scan" value="no_strings">
+                    <label for="scan-none">文字列なし</label>
+                  </div>
+                </div>
+                <label for="detect">検出エンジン
+                  <select id="detect" name="detect">
+                    <option value="auto">auto (自動)</option>
+                    <option value="parse">parse</option>
+                    <option value="regex">regex</option>
+                  </select>
+                </label>
+                <label for="detect_langs">対象言語（CSV／スペース区切り）
+                  <input id="detect_langs" name="detect_langs" type="text" data-tokenize placeholder="go,js,ts,py">
+                </label>
+                <label for="tags">タグ上書き（CSV）
+                  <input id="tags" name="tags" type="text" placeholder="TODO,FIXME,NOTE">
+                </label>
+                <label for="max_file_bytes">最大ファイルサイズ（バイト）
+                  <input id="max_file_bytes" name="max_file_bytes" type="number" min="0" step="1" placeholder="0">
+                </label>
+                <label class="checkbox">
+                  <input type="checkbox" id="no_prefilter" name="no_prefilter" value="1">
+                  git grep プリフィルタを無効化
+                </label>
+              </div>
+            </fieldset>
+
+            <fieldset class="section">
+              <legend>パス・除外 <button type="button" class="help-toggle" aria-expanded="false">?</button></legend>
+              <div class="help-text" hidden>
+                スキャン対象／除外パスを細かく指定できます。改行またはカンマで複数入力できます。
+              </div>
+              <div class="field-grid">
+                <label for="path">対象パス
+                  <textarea id="path" name="path" rows="2" data-multi placeholder="cmd,internal"></textarea>
+                </label>
+                <label for="exclude">除外パス
+                  <textarea id="exclude" name="exclude" rows="2" data-multi placeholder="vendor/**,node_modules/**"></textarea>
+                </label>
+                <label for="path_regex">パス正規表現
+                  <textarea id="path_regex" name="path_regex" rows="2" data-multi placeholder=".*\\.go$"></textarea>
+                </label>
+                <label class="checkbox">
+                  <input type="checkbox" id="exclude_typical" name="exclude_typical" value="1">
+                  定番ディレクトリを除外
+                </label>
+              </div>
+            </fieldset>
+
+            <fieldset class="section">
+              <legend>列と付加情報 <button type="button" class="help-toggle" aria-expanded="false">?</button></legend>
+              <div class="help-text" hidden>
+                表示列と、追加のメタデータ取得を制御します。`fields` に URL／PR 列を含めると自動的に対応フラグが有効になります。
+              </div>
+              <div class="field-grid">
+                <label for="fields">表示列（Ctrl/Cmd + クリックで複数選択）
+                  <select id="fields" name="fields" multiple size="8">
+                    <option value="type">type</option>
+                    <option value="tag">tag</option>
+                    <option value="kind">kind</option>
+                    <option value="lang">lang</option>
+                    <option value="author">author</option>
+                    <option value="email">email</option>
+                    <option value="date">date</option>
+                    <option value="age">age</option>
+                    <option value="commit">commit</option>
+                    <option value="location">location</option>
+                    <option value="text">text</option>
+                    <option value="span">span</option>
+                    <option value="comment">comment</option>
+                    <option value="message">message</option>
+                    <option value="url">url</option>
+                    <option value="commit_url">commit_url</option>
+                    <option value="pr">pr</option>
+                    <option value="prs">prs</option>
+                    <option value="pr_urls">pr_urls</option>
+                  </select>
+                </label>
+                <div class="checkbox-grid">
+                  <label class="checkbox"><input type="checkbox" name="with_comment" value="1"> コメント列</label>
+                  <label class="checkbox"><input type="checkbox" name="with_message" value="1"> コミットメッセージ</label>
+                  <label class="checkbox"><input type="checkbox" name="with_age" value="1"> 経過日数</label>
+                  <label class="checkbox"><input type="checkbox" name="with_commit_link" value="1"> コミットリンク</label>
+                  <label class="checkbox"><input type="checkbox" id="with_pr_links" name="with_pr_links" value="1"> PRリンク</label>
+                </div>
+                <div class="subsection" id="pr-options" hidden>
+                  <label for="pr_state">PR state
+                    <select id="pr_state" name="pr_state">
+                      <option value="">(any)</option>
+                      <option value="open">open</option>
+                      <option value="merged">merged</option>
+                      <option value="closed">closed</option>
+                      <option value="all">all</option>
+                    </select>
+                  </label>
+                  <label for="pr_limit">PR limit
+                    <input id="pr_limit" name="pr_limit" type="number" min="1" max="20" value="3">
+                  </label>
+                  <label for="pr_prefer">PR prefer
+                    <select id="pr_prefer" name="pr_prefer">
+                      <option value="">(none)</option>
+                      <option value="open">open</option>
+                      <option value="merged">merged</option>
+                      <option value="closed">closed</option>
+                      <option value="none">none</option>
+                    </select>
+                  </label>
+                </div>
+                <p class="note" id="field-auto-note">`url` や `pr` を選ぶと対応する `with_*` フラグが自動で有効になります。</p>
+              </div>
+            </fieldset>
+
+            <fieldset class="section">
+              <legend>表示長の制御 <button type="button" class="help-toggle" aria-expanded="false">?</button></legend>
+              <div class="help-text" hidden>
+                表示する文字数を制限します。0 で無制限です。
+              </div>
+              <div class="field-grid">
+                <label for="truncate">truncate
+                  <input id="truncate" name="truncate" type="number" min="0" placeholder="120">
+                </label>
+                <label for="truncate_comment">truncate_comment
+                  <input id="truncate_comment" name="truncate_comment" type="number" min="0">
+                </label>
+                <label for="truncate_message">truncate_message
+                  <input id="truncate_message" name="truncate_message" type="number" min="0">
+                </label>
+              </div>
+            </fieldset>
+
+            <fieldset class="section">
+              <legend>実行・パフォーマンス <button type="button" class="help-toggle" aria-expanded="false">?</button></legend>
+              <div class="help-text" hidden>
+                スキャン対象リポジトリや並列数を設定します。空白のみの差分を無視するかもここで選べます。
+              </div>
+              <div class="field-grid">
+                <label for="repo">リポジトリ
+                  <input id="repo" name="repo" type="text" placeholder=".">
+                </label>
+                <label for="ignore_ws" class="select">空白差分の扱い
+                  <select id="ignore_ws" name="ignore_ws">
+                    <option value="1">空白のみの変更を無視</option>
+                    <option value="0">空白差分も最新扱い</option>
+                  </select>
+                </label>
+                <label for="jobs">jobs
+                  <input id="jobs" name="jobs" type="number" min="1" max="64" placeholder="">
+                </label>
+              </div>
+            </fieldset>
+
+            <fieldset class="section">
+              <legend>プリセット</legend>
+              <p class="note">プリセットを選ぶとフォームが更新されます。上部チップと同じ内容です。</p>
+            </fieldset>
+          </form>
+        </section>
+      </div>
+
+      <section class="results" aria-live="polite">
+        <div id="error-banner" class="banner is-hidden" role="alert">
+          <div class="banner__body">
+            <span id="error-message"></span>
+          </div>
+          <button type="button" class="btn btn-icon" id="error-close" aria-label="エラーを閉じる">×</button>
+        </div>
+
+        <div id="progress" class="progress-panel is-hidden" role="status" aria-live="polite">
+          <div class="progress-head">
+            <progress id="progress-meter" value="0" max="1"></progress>
+            <div class="progress-meta">
+              <span id="progress-stage" class="progress-stage">scan</span>
+              <span id="progress-eta" class="progress-stat"></span>
+              <span id="progress-rate" class="progress-stat"></span>
+              <span id="progress-elapsed" class="progress-stat"></span>
+            </div>
+          </div>
+          <div class="progress-stages" role="list">
+            <span id="st-scan" class="stage" role="listitem">scan</span>
+            <span id="st-attr" class="stage" role="listitem">attr</span>
+            <span id="st-pr" class="stage" role="listitem">pr</span>
+          </div>
+          <div class="progress-footer">
+            <span id="progress-stats" class="progress-stat"></span>
+            <button type="button" class="btn" id="progress-cancel">キャンセル</button>
+          </div>
+        </div>
+
+        <div class="results-toolbar">
+          <div class="results-count" id="result-count">結果: 0 件</div>
+          <div class="results-actions">
+            <button type="button" class="btn" id="export-json" disabled>JSONエクスポート</button>
+            <button type="button" class="btn" id="export-tsv" disabled>TSVエクスポート</button>
+          </div>
+        </div>
+
+        <div id="result-errors" class="muted"></div>
+        <div id="result-table" class="table-shell" role="region" aria-live="polite"></div>
+      </section>
+    </main>
+
+    <footer class="actionbar" role="contentinfo">
+      <div class="action-buttons">
+        <button type="submit" form="opts" class="btn btn-primary">スキャン</button>
+        <button type="button" class="btn" id="cancel-scan">キャンセル</button>
+        <button type="reset" form="opts" class="btn" id="reset-form">リセット</button>
+      </div>
+      <div class="share-fields">
+        <div class="share-field">
+          <label for="cli-command">CLI コマンド</label>
+          <textarea id="cli-command" rows="2" readonly></textarea>
+          <button type="button" class="btn btn-icon" data-copy-target="#cli-command" aria-label="CLI コマンドをコピー">⧉</button>
+        </div>
+        <div class="share-field">
+          <label for="share-url">共有URL</label>
+          <input id="share-url" type="text" readonly>
+          <button type="button" class="btn btn-icon" data-copy-target="#share-url" aria-label="共有URLをコピー">⧉</button>
+        </div>
+      </div>
+    </footer>
   </div>
-  <form id="f">
-    <label>type:
-      <select name="type">
-        <option>both</option>
-        <option>todo</option>
-        <option>fixme</option>
-      </select>
-    </label>
-    <label>mode:
-      <select name="mode">
-        <option>last</option>
-        <option>first</option>
-      </select>
-    </label>
-    <label>author (regexp): <input name="author" type="text"></label>
-    <label>path (CSV ok): <input name="path" type="text" placeholder="src,pkg"></label>
-    <label>exclude (CSV ok): <input name="exclude" type="text" placeholder="vendor/**"></label>
-    <label>path regex: <input name="path_regex" type="text" placeholder="\\.go$"></label>
-    <label><input type="checkbox" name="with_comment"> comment</label>
-    <label><input type="checkbox" name="with_message"> message</label>
-    <label><input type="checkbox" name="with_commit_link"> commit link</label>
-    <label><input type="checkbox" name="with_pr_links"> PR links</label>
-    <label>PR state:
-      <select name="pr_state">
-        <option value="all">all</option>
-        <option value="open">open</option>
-        <option value="merged">merged</option>
-        <option value="closed">closed</option>
-      </select>
-    </label>
-    <label>PR prefer:
-      <select name="pr_prefer">
-        <option value="open">open</option>
-        <option value="merged">merged</option>
-        <option value="closed">closed</option>
-        <option value="none">none</option>
-      </select>
-    </label>
-    <label>PR limit: <input type="number" name="pr_limit" min="1" max="20" value="3" inputmode="numeric" pattern="[0-9]*"></label>
-    <label><input type="checkbox" name="ignore_ws" checked> ignore whitespace</label>
-    <label><input type="checkbox" name="exclude_typical"> exclude typical dirs</label>
-    <label>jobs: <input type="number" name="jobs" min="1" max="64" inputmode="numeric" pattern="[0-9]*" placeholder="auto"></label>
-    <label>truncate: <input type="text" name="truncate" value="120"></label>
-    <button type="submit">Scan</button>
-  </form>
-  <p class="small">Tip: Same params as CLI. Example: <code>/api/scan?type=todo&amp;mode=first&amp;with_comment=1</code></p>
-  <div id="progress" class="progress-wrap" aria-live="polite" hidden>
-    <div class="progress-header">
-      <strong id="progress-stage">scan</strong>
-      <span id="progress-stats" class="muted"></span>
-      <button type="button" id="progress-cancel" class="linklike">キャンセル</button>
-    </div>
 
-    <ol class="stepper" aria-label="Stages">
-      <li id="st-scan" class="current">scan</li>
-      <li id="st-attr">attr</li>
-      <li id="st-pr">pr</li>
-    </ol>
-
-    <div id="progressbar" class="progressbar" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0" aria-label="Stage progress">
-      <div id="progressbar-inner" style="width:0%"></div>
-    </div>
-
-    <div class="progress-footer muted">
-      <span id="progress-eta">ETA: —</span>
-      <span id="progress-rate">Rate: —</span>
-      <span id="progress-elapsed">Elapsed: —</span>
-    </div>
-  </div>
-  <div id="out"></div>
-  <script>
-  const f=document.getElementById('f');
-  const out=document.getElementById('out');
-  const banner=document.getElementById('error-banner');
-  const bannerMsg=document.getElementById('error-message');
-  const bannerClose=document.getElementById('error-close');
-  const prog=document.getElementById('progress');
-  const progInner=document.getElementById('progressbar-inner');
-  const progBar=document.getElementById('progressbar');
-  const progStage=document.getElementById('progress-stage');
-  const progStats=document.getElementById('progress-stats');
-  const progETA=document.getElementById('progress-eta');
-  const progRate=document.getElementById('progress-rate');
-  const progElapsed=document.getElementById('progress-elapsed');
-  const btnCancel=document.getElementById('progress-cancel');
-  const stScan=document.getElementById('st-scan');
-  const stAttr=document.getElementById('st-attr');
-  const stPr=document.getElementById('st-pr');
-
-  let es=null;
-  let lastSnap=null;
-  let rafId=0;
-  let fetchAbort=null; // AbortController | null
-  let latestResult=null;
-  let tableRows=[];
-  let sortKey=null;
-  let sortDesc=false;
-
-  function showError(msg){
-    bannerMsg.textContent=msg;
-    banner.style.display='flex';
-  }
-
-  function hideError(){
-    banner.style.display='none';
-    bannerMsg.textContent='';
-  }
-
-  function escText(value){
-    return String(value||'')
-      .replace(/&/g,'&amp;')
-      .replace(/</g,'&lt;')
-      .replace(/>/g,'&gt;');
-  }
-
-  function escAttr(value){
-    return String(value||'')
-      .replace(/&/g,'&amp;')
-      .replace(/</g,'&lt;')
-      .replace(/>/g,'&gt;')
-      .replace(/"/g,'&quot;')
-      .replace(/'/g,'&#39;');
-  }
-
-  function collapseWhitespace(value){
-    return String(value||'').replace(/\s+/g,' ').trim();
-  }
-
-  function ellipsize(text,max){
-    const raw=String(text||'');
-    if(!max||max<=0||raw.length<=max){
-      return raw;
-    }
-    if(max<=1){
-      return raw.slice(0,max);
-    }
-    return raw.slice(0,max-1)+'…';
-  }
-
-  function normalizePRTooltip(body){
-    const collapsed=String(body||'')
-      .replace(/\r?\n/g,' ')
-      .replace(/\\[rn]/g,' ')
-      .replace(/\s+/g,' ')
-      .trim();
-    if(!collapsed){
-      return '';
-    }
-    return ellipsize(collapsed,280);
-  }
-
-  function renderBadge(kind){
-    const raw=String(kind||'');
-    if(!raw){
-      return '';
-    }
-    const upper=raw.toUpperCase();
-    let dataType='OTHER';
-    if(upper==='TODO' || upper==='FIXME'){
-      dataType=upper;
-    }
-    return '<span class="badge" data-type="'+dataType+'">'+escText(upper)+'</span>';
-  }
-
-  function renderResultTable(data,opts){
-    const info=(data&&typeof data==='object')?data:{};
-    const options=opts||{};
-    const rowsSource=options.rows;
-    const rows=Array.isArray(rowsSource)?rowsSource:(Array.isArray(info.items)?info.items:[]);
-    const errs=Array.isArray(info.errors)?info.errors:[];
-    const parts=[];
-    if(errs.length>0){
-      let list='<ul>';
-      for(const e of errs){
-        const fileRaw=e&&e.file?e.file:'(unknown)';
-        const lineRaw=e&&typeof e.line==='number'&&e.line>0?String(e.line):'—';
-        const loc=fileRaw+':'+lineRaw;
-        const stage=e&&e.stage?e.stage:'git';
-        list+='<li><code>'+escText(loc)+'</code> ['+escText(stage)+'] '+escText(e&&e.message?e.message:'')+'</li>';
-      }
-      list+='</ul>';
-      parts.push('<div class="errors"><strong>'+errs.length+' error(s)</strong>'+list+'</div>');
-    }
-    if(!rows || rows.length===0){
-      parts.push('<p>No results.</p>');
-      return parts.join('');
-    }
-    const headerMeta=buildHeaderMeta(info);
-    const activeKey=options.sortKey?String(options.sortKey):null;
-    const activeDesc=!!options.sortDesc;
-    const head=headerMeta.map(meta=>{
-      const classes=['sort-btn'];
-      if(activeKey===meta.key){
-        classes.push(activeDesc?'desc':'asc');
-      }
-      const ariaSort=activeKey===meta.key?(activeDesc?'descending':'ascending'):'none';
-      return '<th aria-sort="'+ariaSort+'"><button type="button" class="'+classes.join(' ')+'" data-key="'+escAttr(meta.key)+'">'+escText(meta.label)+'</button></th>';
-    }).join('');
-    let tableHTML='<table><thead><tr>'+head+'</tr></thead><tbody>';
-    for(const r of rows){
-      const cells=[];
-      for(const meta of headerMeta){
-        cells.push('<td>'+renderTableCell(meta.key,r,info)+'</td>');
-      }
-      tableHTML+='<tr>'+cells.join('')+'</tr>';
-    }
-    tableHTML+='</tbody></table>';
-    parts.push(tableHTML);
-    return parts.join('');
-  }
-
-  function buildHeaderMeta(info){
-    const meta=[
-      {key:'kind',label:'TYPE'},
-      {key:'author',label:'AUTHOR'},
-      {key:'email',label:'EMAIL'},
-      {key:'date',label:'DATE'}
-    ];
-    if(info&&info.has_age){
-      meta.push({key:'age_days',label:'AGE'});
-    }
-    meta.push({key:'commit',label:'COMMIT'});
-    meta.push({key:'location',label:'LOCATION'});
-    if(info&&info.has_url){
-      meta.push({key:'url',label:'URL'});
-    }
-    if(info&&info.has_prs){
-      meta.push({key:'prs',label:'PRS'});
-    }
-    if(info&&info.has_comment){
-      meta.push({key:'comment',label:'COMMENT'});
-    }
-    if(info&&info.has_message){
-      meta.push({key:'message',label:'MESSAGE'});
-    }
-    return meta;
-  }
-
-  function renderTableCell(key,row){
-    const r=row||{};
-    switch(key){
-      case 'kind':
-        return renderBadge(r.kind);
-      case 'author':
-        return escText(r.author);
-      case 'email':
-        return escText(r.email);
-      case 'date':
-        return escText(r.date);
-      case 'age_days':{
-        const ageRaw=(typeof r.age_days==='number'&&isFinite(r.age_days))?String(r.age_days):(r.age_days===0?'0':'');
-        return escText(ageRaw);
-      }
-      case 'commit':{
-        const commitRaw=r.commit?String(r.commit).slice(0,8):'';
-        return '<code>'+escText(commitRaw)+'</code>';
-      }
-      case 'location':{
-        const fileRaw=r.file?String(r.file):'';
-        const lineRaw=(typeof r.line==='number'&&r.line>0)?String(r.line):'';
-        return '<code>'+escText(fileRaw+':'+lineRaw)+'</code>';
-      }
-      case 'url':{
-        const urlRaw=r.url?String(r.url):'';
-        if(!urlRaw){
-          return '';
-        }
-        const href=escAttr(urlRaw);
-        return '<a class="link-icon" href="'+href+'" target="_blank" rel="noopener noreferrer" aria-label="GitHub で開く"><span aria-hidden="true">🔗</span></a>';
-      }
-      case 'prs':
-        return renderPRCell(r.prs);
-      case 'comment':
-        return escText(r.comment);
-      case 'message':
-        return escText(r.message);
-      default:
-        return escText(r[key]);
-    }
-  }
-
-  function renderPRCell(value){
-    const list=Array.isArray(value)?value:[];
-    if(!list.length){
-      return '';
-    }
-    const entries=[];
-    for(const pr of list){
-      const info=pr||{};
-      const numValue=typeof info.number==='number'?info.number:Number(info.number);
-      const hasNumber=Number.isFinite(numValue)&&numValue>0;
-      const numberText=hasNumber?String(Math.trunc(numValue)):'';
-      const stateRaw=info.state!=null?String(info.state):'';
-      const state=stateRaw.trim().toLowerCase()||'unknown';
-      const titleRaw=info.title!=null?String(info.title):'';
-      const titleText=titleRaw.trim();
-      const tooltip=normalizePRTooltip(info.body);
-      const anchorLabel=hasNumber?'#'+numberText:(titleText||state||'#');
-      const ariaParts=[];
-      if(hasNumber){
-        ariaParts.push('PR #'+numberText);
-      }else{
-        ariaParts.push('Pull request');
-        if(titleText){
-          ariaParts.push(titleText);
-        }
-      }
-      if(state){
-        ariaParts.push(state);
-      }
-      const ariaLabel=ariaParts.join(' ').trim();
-      let leading=escText(anchorLabel);
-      if(info.url){
-        const attrs=['href="'+escAttr(String(info.url))+'"','target="_blank"','rel="noopener noreferrer"'];
-        if(ariaLabel){
-          attrs.push('aria-label="'+escAttr(ariaLabel)+'"');
-        }
-        if(tooltip){
-          attrs.push('title="'+escAttr(tooltip)+'"');
-        }
-        leading='<a '+attrs.join(' ')+'>'+escText(anchorLabel)+'</a>';
-      }else if(tooltip){
-        leading='<span title="'+escAttr(tooltip)+'">'+leading+'</span>';
-      }
-      let titleSuffix='';
-      if(hasNumber && titleText){
-        titleSuffix=' '+escText(titleText);
-      }else if(!hasNumber && titleText && anchorLabel!==titleText){
-        titleSuffix=' '+escText(titleText);
-      }
-      entries.push(leading+titleSuffix+' ('+escText(state)+')');
-    }
-    return entries.join('; ');
-  }
-
-  function sortRows(rows,key,desc){
-    const base=Array.isArray(rows)?rows.slice():[];
-    if(!key){
-      return base;
-    }
-    base.sort((left,right)=>{
-      const leftEmpty=isValueEmptyForKey(left,key);
-      const rightEmpty=isValueEmptyForKey(right,key);
-      if(leftEmpty!==rightEmpty){
-        return leftEmpty?1:-1;
-      }
-      const cmp=compareRows(left,right,key);
-      return desc?-cmp:cmp;
-    });
-    return base;
-  }
-
-  function isValueEmptyForKey(row,key){
-    const r=row||{};
-    switch(key){
-      case 'age_days':
-        return !(typeof r.age_days==='number' && isFinite(r.age_days));
-      case 'commit':
-      case 'date':
-      case 'author':
-      case 'email':
-      case 'kind':
-      case 'comment':
-      case 'message':
-      case 'url':{
-        const val=r[key];
-        return val==null || String(val).trim()==='';
-      }
-      case 'location':{
-        const file=r.file!=null?String(r.file).trim():'';
-        const hasLine=typeof r.line==='number' && r.line>0;
-        return !file && !hasLine;
-      }
-      case 'prs':
-        return !(Array.isArray(r.prs) && r.prs.length>0);
-      default:{
-        const val=r[key];
-        return val==null || String(val).trim()==='';
-      }
-    }
-  }
-
-  function compareRows(a,b,key){
-    switch(key){
-      case 'age_days':
-        return compareNumbers(a&&a.age_days,b&&b.age_days);
-      case 'commit':
-        return compareStrings(a&&a.commit,b&&b.commit);
-      case 'date':
-        return compareStrings(a&&a.date,b&&b.date);
-      case 'author':
-        return compareStrings(a&&a.author,b&&b.author);
-      case 'email':
-        return compareStrings(a&&a.email,b&&b.email);
-      case 'kind':
-        return compareStrings(a&&a.kind,b&&b.kind);
-      case 'comment':
-        return compareStrings(a&&a.comment,b&&b.comment);
-      case 'message':
-        return compareStrings(a&&a.message,b&&b.message);
-      case 'url':
-        return compareStrings(a&&a.url,b&&b.url);
-      case 'location':
-        return compareLocation(a,b);
-      case 'prs':
-        return comparePRs(a,b);
-      default:
-        return compareStrings(a&&a[key],b&&b[key]);
-    }
-  }
-
-  function compareStrings(a,b){
-    const sa=a==null?'':String(a).trim();
-    const sb=b==null?'':String(b).trim();
-    const emptyA=sa==='';
-    const emptyB=sb==='';
-    if(emptyA && emptyB){
-      return 0;
-    }
-    if(emptyA){
-      return 1;
-    }
-    if(emptyB){
-      return -1;
-    }
-    if(sa<sb){return -1;}
-    if(sa>sb){return 1;}
-    return 0;
-  }
-
-  function compareNumbers(a,b){
-    const validA=typeof a==='number' && isFinite(a);
-    const validB=typeof b==='number' && isFinite(b);
-    if(!validA && !validB){
-      return 0;
-    }
-    if(!validA){
-      return 1;
-    }
-    if(!validB){
-      return -1;
-    }
-    if(a<b){return -1;}
-    if(a>b){return 1;}
-    return 0;
-  }
-
-  function compareLocation(a,b){
-    const fileA=a&&a.file!=null?String(a.file).trim():'';
-    const fileB=b&&b.file!=null?String(b.file).trim():'';
-    const rawLineA=a&&typeof a.line==='number'&&a.line>0?a.line:NaN;
-    const rawLineB=b&&typeof b.line==='number'&&b.line>0?b.line:NaN;
-    const missingA=!fileA && !Number.isFinite(rawLineA);
-    const missingB=!fileB && !Number.isFinite(rawLineB);
-    if(missingA && missingB){
-      return 0;
-    }
-    if(missingA){
-      return 1;
-    }
-    if(missingB){
-      return -1;
-    }
-    if(fileA<fileB){return -1;}
-    if(fileA>fileB){return 1;}
-    const validA=Number.isFinite(rawLineA);
-    const validB=Number.isFinite(rawLineB);
-    if(!validA && !validB){
-      return 0;
-    }
-    if(!validA){
-      return 1;
-    }
-    if(!validB){
-      return -1;
-    }
-    if(rawLineA<rawLineB){return -1;}
-    if(rawLineA>rawLineB){return 1;}
-    return 0;
-  }
-
-  function comparePRs(a,b){
-    const listA=Array.isArray(a&&a.prs)?a.prs:[];
-    const listB=Array.isArray(b&&b.prs)?b.prs:[];
-    if(listA.length===0 && listB.length===0){
-      return 0;
-    }
-    if(listA.length===0){
-      return 1;
-    }
-    if(listB.length===0){
-      return -1;
-    }
-    const firstA=listA[0]||{};
-    const firstB=listB[0]||{};
-    const numA=typeof firstA.number==='number'?firstA.number:Number(firstA.number);
-    const numB=typeof firstB.number==='number'?firstB.number:Number(firstB.number);
-    const hasNumA=Number.isFinite(numA)&&numA>0;
-    const hasNumB=Number.isFinite(numB)&&numB>0;
-    if(hasNumA && hasNumB){
-      if(numA<numB){return -1;}
-      if(numA>numB){return 1;}
-      return 0;
-    }
-    if(hasNumA){
-      return -1;
-    }
-    if(hasNumB){
-      return 1;
-    }
-    const titleCmp=compareStrings(firstA.title,firstB.title);
-    if(titleCmp!==0){
-      return titleCmp;
-    }
-    return compareStrings(firstA.state,firstB.state);
-  }
-
-  function resetProgressUI(){
-    progStage.textContent='scan';
-    progStats.textContent='0/— done';
-    progETA.textContent='ETA: —';
-    progRate.textContent='Rate: —';
-    progElapsed.textContent='Elapsed: —';
-    updateProgressBar(0,false);
-    setStepper('scan');
-  }
-
-  function showProgressUI(){
-    prog.hidden=false;
-    resetProgressUI();
-    prog.setAttribute('aria-busy','true');
-  }
-
-  function hideProgressUI(){
-    prog.hidden=true;
-    prog.removeAttribute('aria-busy');
-    lastSnap=null;
-    if(rafId && typeof cancelAnimationFrame==='function'){
-      cancelAnimationFrame(rafId);
-      rafId=0;
-    }
-    btnCancel.onclick=null;
-  }
-
-  function setStepper(stage){
-    const stages={scan:stScan,attr:stAttr,pr:stPr};
-    for(const key of Object.keys(stages)){
-      const el=stages[key];
-      if(!el){continue;}
-      el.classList.remove('current');
-      el.classList.remove('done');
-    }
-    if(stage==='scan'){
-      stScan.classList.add('current');
-    }else if(stage==='attr'){
-      stScan.classList.add('done');
-      stAttr.classList.add('current');
-    }else if(stage==='pr'){
-      stScan.classList.add('done');
-      stAttr.classList.add('done');
-      stPr.classList.add('current');
-    }
-  }
-
-  function togglePRStepVisibility(enabled){
-    if(!stPr){return;}
-    stPr.style.display = enabled ? '' : 'none';
-  }
-
-  function updateProgressBar(percent,determinate){
-    const pct=Math.max(0,Math.min(100,percent||0));
-    progInner.style.width=pct+'%';
-    if(progBar){
-      if(determinate){
-        progBar.setAttribute('aria-valuenow',String(Math.round(pct)));
-        progBar.removeAttribute('aria-valuetext');
-      }else{
-        progBar.removeAttribute('aria-valuenow');
-        progBar.setAttribute('aria-valuetext','in progress');
-      }
-    }
-  }
-
-  function renderProgressOnce(){
-    rafId=0;
-    if(!lastSnap){
-      return;
-    }
-    const s=lastSnap;
-    const nf = (typeof Intl!=='undefined'&&Intl.NumberFormat)?new Intl.NumberFormat():{format:(v)=>String(v)};
-    progStage.textContent=s.stage||'';
-    setStepper(s.stage);
-    const determinate=!!(s.total&&s.total>0);
-    let percent=0;
-    if(determinate){
-      percent=(s.done/s.total)*100;
-    }
-    updateProgressBar(percent,determinate);
-    const totalLabel=determinate?nf.format(s.total):'—';
-    const statText=nf.format(s.done||0)+'/'+totalLabel+' done';
-    const rateLabel=typeof s.rate_per_sec==='number'&&isFinite(s.rate_per_sec)?nf.format(Number(s.rate_per_sec.toFixed(1)))+'/sec':'—';
-    function fmtEta(sec){
-      if(!(typeof sec==='number'&&isFinite(sec))){return '—';}
-      const mm=Math.floor(sec/60);
-      const ss=Math.round(sec%60);
-      return nf.format(Number(sec.toFixed(1)))+'s ('+mm+':'+String(ss).padStart(2,'0')+')';
-    }
-    const etaLabel=fmtEta(s.eta_sec_p50);
-    const elapsedLabel=typeof s.elapsed_sec==='number'&&isFinite(s.elapsed_sec)?s.elapsed_sec.toFixed(1)+'s':'—';
-    progStats.textContent=statText;
-    progRate.textContent='Rate: '+rateLabel;
-    progETA.textContent='ETA: '+etaLabel;
-    progElapsed.textContent='Elapsed: '+elapsedLabel;
-  }
-
-  function scheduleRender(){
-    if(typeof requestAnimationFrame!=='function'){
-      renderProgressOnce();
-      return;
-    }
-    if(rafId){
-      return;
-    }
-    rafId=requestAnimationFrame(renderProgressOnce);
-  }
-
-  function closeStream(){
-    if(es){
-      try{es.close();}catch(_){ }
-      es=null;
-    }
-  }
-
-  function renderTableWithSort(){
-    const base=(latestResult&&typeof latestResult==='object')?latestResult:{};
-    const sorted=sortRows(tableRows,sortKey,sortDesc);
-    out.innerHTML=renderResultTable(base,{rows:sorted,sortKey:sortKey,sortDesc:sortDesc});
-    attachSortHandlers();
-  }
-
-  function attachSortHandlers(){
-    const buttons=out.querySelectorAll('th .sort-btn');
-    for(const btn of buttons){
-      btn.addEventListener('click',(ev)=>{
-        ev.preventDefault();
-        const key=btn.getAttribute('data-key');
-        if(!key){
-          return;
-        }
-        if(sortKey===key){
-          sortDesc=!sortDesc;
-        }else{
-          sortKey=key;
-          sortDesc=false;
-        }
-        renderTableWithSort();
-      });
-    }
-  }
-
-  function updateResultData(data){
-    latestResult=(data&&typeof data==='object')?data:null;
-    tableRows=Array.isArray(latestResult&&latestResult.items)?latestResult.items.slice():[];
-    sortKey=null;
-    sortDesc=false;
-    renderTableWithSort();
-  }
-
-  async function startScanWithFetch(q){
-    hideProgressUI();
-    out.innerHTML='';
-    latestResult=null;
-    tableRows=[];
-    sortKey=null;
-    sortDesc=false;
-    // フォールバック実行中のキャンセル対応
-    fetchAbort = new AbortController();
-    const { signal } = fetchAbort;
-    try{
-      const res=await fetch('/api/scan?'+q.toString(), { signal });
-      const raw=await res.text();
-      if(!res.ok){
-        let msg='HTTP '+res.status;
-        if(res.statusText){
-          msg+=' '+res.statusText;
-        }
-        const trimmed=raw.trim();
-        if(trimmed){
-          msg+=': '+trimmed;
-        }
-        throw new Error(msg);
-      }
-      let data=null;
-      const trimmed=raw.trim();
-      if(trimmed!==''){
-        try{
-          data=JSON.parse(trimmed);
-        }catch(parseErr){
-          const detail=parseErr instanceof Error?parseErr.message:String(parseErr);
-          throw new Error('Failed to parse response JSON: '+detail);
-        }
-      }
-      updateResultData(data);
-    }catch(err){
-      if(err && err.name === 'AbortError'){
-        // キャンセル時は静かに終了
-        return;
-      }
-      console.error(err);
-      showError(err instanceof Error?err.message:String(err));
-    } finally {
-      fetchAbort = null;
-    }
-  }
-
-  function startScanWithSSE(q){
-    closeStream();
-    out.innerHTML='';
-    latestResult=null;
-    tableRows=[];
-    sortKey=null;
-    sortDesc=false;
-    showProgressUI();
-    try{
-      es=new EventSource('/api/scan/stream?'+q.toString());
-    }catch(err){
-      hideProgressUI();
-      showError(err instanceof Error?err.message:String(err));
-      return;
-    }
-
-    es.addEventListener('progress',(ev)=>{
-      try{
-        lastSnap=JSON.parse(ev.data);
-        scheduleRender();
-      }catch(parseErr){
-        console.warn('progress parse failed',parseErr);
-      }
-    });
-
-    es.addEventListener('result',(ev)=>{
-      try{
-        const res=JSON.parse(ev.data);
-        hideProgressUI();
-        updateResultData(res);
-      }catch(parseErr){
-        console.error(parseErr);
-        showError(parseErr instanceof Error?parseErr.message:String(parseErr));
-      }finally{
-        closeStream();
-      }
-    });
-
-    function handleServerError(ev){
-      if(!ev || typeof ev.data==='undefined'){
-        return;
-      }
-      try{
-        const payload=JSON.parse(ev.data||'{}');
-        showError(payload&&payload.message?payload.message:'stream error');
-      }catch(parseErr){
-        showError(parseErr instanceof Error?parseErr.message:String(parseErr));
-      }
-      hideProgressUI();
-      closeStream();
-    }
-    es.addEventListener('error', handleServerError);
-    es.addEventListener('server_error', handleServerError);
-
-    es.onerror=(ev)=>{
-      if(ev && typeof ev.data!=='undefined'){
-        return;
-      }
-      if(!es){
-        return;
-      }
-      const label=(lastSnap&&es.readyState===EventSource.CONNECTING)?'reconnecting…':'connecting…';
-      progStats.textContent=label;
-    };
-
-    btnCancel.onclick=()=>{
-      closeStream();
-      if(fetchAbort){
-        try{ fetchAbort.abort(); }catch(_){ }
-        fetchAbort=null;
-      }
-      hideProgressUI();
-    };
-  }
-
-  function buildQueryParams(){
-    const fd=new FormData(f);
-    const q=new URLSearchParams(fd);
-    const ignoreEl=f.elements.namedItem('ignore_ws');
-    if(ignoreEl instanceof HTMLInputElement){
-      if(ignoreEl.checked){
-        q.delete('ignore_ws');
-      }else{
-        q.set('ignore_ws','0');
-      }
-    }
-    for(const key of ['path','exclude','path_regex']){
-      const values=q.getAll(key);
-      q.delete(key);
-      const cleaned=[];
-      for(const value of values){
-        if(value==null){
-          continue;
-        }
-        for(const piece of String(value).split(',')){
-          const trimmed=piece.trim();
-          if(trimmed){
-            cleaned.push(trimmed);
-          }
-        }
-      }
-      for(const entry of cleaned){
-        q.append(key,entry);
-      }
-    }
-    const excludeTypical=f.elements.namedItem('exclude_typical');
-    if(excludeTypical instanceof HTMLInputElement){
-      if(excludeTypical.checked){
-        q.set('exclude_typical','1');
-      }else{
-        q.delete('exclude_typical');
-      }
-    }
-    const jobsEl=f.elements.namedItem('jobs');
-    if(jobsEl instanceof HTMLInputElement){
-      if((jobsEl.value||'').trim()===''){
-        q.delete('jobs');
-      }
-    }
-    return q;
-  }
-
-  bannerClose.addEventListener('click',(e)=>{
-    e.preventDefault();
-    hideError();
-  });
-
-  // PR ステップの動的表示（初期化）
-  (function(){
-    const prCheck=f.elements.namedItem('with_pr_links');
-    if(prCheck instanceof HTMLInputElement){
-      togglePRStepVisibility(prCheck.checked);
-      prCheck.addEventListener('change',()=>togglePRStepVisibility(prCheck.checked));
-    }
-  })();
-
-  f.addEventListener('submit',(e)=>{
-    e.preventDefault();
-    hideError();
-    const q=buildQueryParams();
-    // 送信直前にも反映
-    {
-      const prCheck=f.elements.namedItem('with_pr_links');
-      if(prCheck instanceof HTMLInputElement){
-        togglePRStepVisibility(prCheck.checked);
-      }
-    }
-    if('EventSource' in window){
-      startScanWithSSE(q);
-    }else{
-      startScanWithFetch(q);
-    }
-  });
-  </script>
+  <script type="module" src="{{.ScriptPath}}"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- rebuild the HTML shell with a sticky toolbar, collapsible filter panel, refreshed results area, and action footer driven by class toggles
- rework the CSS tokens, grids, and component styling to deliver the new layout, progress meter, and copy feedback without inline styles
- refactor the web UI script to manage visibility through classes, surface CLI previews/help, upgrade copy handling, and rely on the HTML progress element

## Testing
- make build
- golangci-lint run
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68f26dab16348320b88ffee8076606c0